### PR TITLE
Add NFT Type to the catalog

### DIFF
--- a/cadence/__test__/src/examplenft.js
+++ b/cadence/__test__/src/examplenft.js
@@ -43,3 +43,9 @@ export const getExampleNFTCollectionLength = async (account) => {
 
     return executeScript({ name, args });
 };
+
+export const getExampleNFTType = async () => {
+    const name = 'get_examplenft_type';
+
+    return executeScript({ name })
+}

--- a/cadence/__test__/src/nftcatalog.js
+++ b/cadence/__test__/src/nftcatalog.js
@@ -8,21 +8,21 @@ export const deployNFTCatalog = async () => {
   return deployContractByName({ to: NFTCatalogAdmin, name: 'NFTCatalogAdmin' })
 }
 
-export const addToCatalogAdmin = async (nftName, contractName, nftAddressLocation, storagePath, publicPath) => {
+export const addToCatalogAdmin = async (nftName, contractName, nftAddressLocation, nftTypeIdentifier, storagePath, publicPath) => {
   const NFTCatalogAdmin = await getAdminAddress();
   const name = 'add_to_nft_catalog_admin';
 
   const signers = [NFTCatalogAdmin];
-  const args = [nftName, contractName, nftAddressLocation, storagePath, publicPath];
+  const args = [nftName, contractName, nftAddressLocation, nftTypeIdentifier, storagePath, publicPath];
 
   return sendTransaction({ name, args, signers });
 }
 
-export const addToCatalog = async (proxyAccount, nftName, contractName, nftAddressLocation, storagePath, publicPath) => {
+export const addToCatalog = async (proxyAccount, nftName, contractName, nftAddressLocation, nftTypeIdentifier, storagePath, publicPath) => {
   const name = 'add_to_nft_catalog';
 
   const signers = [proxyAccount];
-  const args = [nftName, contractName, nftAddressLocation, storagePath, publicPath];
+  const args = [nftName, contractName, nftAddressLocation, nftTypeIdentifier, storagePath, publicPath];
 
   return sendTransaction({ name, args, signers });
 }
@@ -45,9 +45,9 @@ export const sendAdminProxyCapability = async (ownerAccount) => {
   return sendTransaction({ name, args, signers });
 }
 
-export const proposeNFTToCatalog = async (account, nftName, contractName, nftAddressLocation, storagePath, publicPath, message) => {
+export const proposeNFTToCatalog = async (account, nftName, contractName, nftAddressLocation, nftTypeIdentifier, storagePath, publicPath, message) => {
   const name = 'propose_nft_to_catalog';
-  const args = [nftName, contractName, nftAddressLocation, storagePath, publicPath, message];
+  const args = [nftName, contractName, nftAddressLocation, nftTypeIdentifier, storagePath, publicPath, message];
   const signers = [account];
 
   return sendTransaction({ name, args, signers });

--- a/cadence/__test__/test/nftcatalog.test.js
+++ b/cadence/__test__/test/nftcatalog.test.js
@@ -20,7 +20,8 @@ import {
   removeNFTProposal
 } from '../src/nftcatalog';
 import {
-  deployExampleNFT
+  deployExampleNFT,
+  getExampleNFTType
 } from '../src/examplenft';
 
 
@@ -49,10 +50,13 @@ describe('NFT Catalog Test Suite', () => {
     let res = await deployExampleNFT();
     const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
 
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
     await shallPass(addToCatalogAdmin(
       nftCreationEvent.data.contract,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.address,
+      nftTypeIdentifier,
       'exampleNFTCollection',
       'exampleNFTCollection'
     ));
@@ -86,11 +90,14 @@ describe('NFT Catalog Test Suite', () => {
     let res = await deployExampleNFT();
     const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
 
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
     await shallPass(addToCatalog(
       Alice,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.address,
+      nftTypeIdentifier,
       'exampleNFTCollection',
       'exampleNFTCollection'
     ));
@@ -100,6 +107,7 @@ describe('NFT Catalog Test Suite', () => {
     expect(result.name).toBe(nftCreationEvent.data.contract);
     expect(error).toBe(null);
   });
+
 
   it('should be able to approve proposals', async () => {
     await deployNFTCatalog();
@@ -114,11 +122,15 @@ describe('NFT Catalog Test Suite', () => {
     const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
 
     const Bob = await getAccountAddress('Bob');
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
     await shallPass(proposeNFTToCatalog(
       Bob,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.address,
+      nftTypeIdentifier,
       'exampleNFTCollection',
       'exampleNFTCollection',
       'Please add my NFT to the Catalog'
@@ -142,6 +154,7 @@ describe('NFT Catalog Test Suite', () => {
     expect(error).toBe(null);
   });
 
+
   it('should be able to reject proposals', async () => {
     await deployNFTCatalog();
 
@@ -155,11 +168,15 @@ describe('NFT Catalog Test Suite', () => {
     const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
 
     const Bob = await getAccountAddress('Bob');
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
     await shallPass(proposeNFTToCatalog(
       Bob,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.address,
+      nftTypeIdentifier,
       'exampleNFTCollection',
       'exampleNFTCollection',
       'Please add my NFT to the Catalog'
@@ -181,6 +198,7 @@ describe('NFT Catalog Test Suite', () => {
     expect(result).toBe(null);
   });
 
+
   it('should be able to remove proposals', async () => {
     await deployNFTCatalog();
 
@@ -194,11 +212,15 @@ describe('NFT Catalog Test Suite', () => {
     const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
 
     const Bob = await getAccountAddress('Bob');
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
     await shallPass(proposeNFTToCatalog(
       Bob,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.contract,
       nftCreationEvent.data.address,
+      nftTypeIdentifier,
       'exampleNFTCollection',
       'exampleNFTCollection',
       'Please add my NFT to the Catalog'

--- a/cadence/contracts/ExampleNFT.cdc
+++ b/cadence/contracts/ExampleNFT.cdc
@@ -42,7 +42,8 @@ pub contract ExampleNFT: NonFungibleToken {
         pub fun getViews(): [Type] {
             return [
                 Type<MetadataViews.Display>(),
-                Type<MetadataViews.Royalties>()
+                Type<MetadataViews.Royalties>(),
+                Type<MetadataViews.NFTCollectionData>()
             ]
         }
 
@@ -59,6 +60,18 @@ pub contract ExampleNFT: NonFungibleToken {
                 case Type<MetadataViews.Royalties>():
                     return MetadataViews.Royalties(
                         self.royalties
+                    )
+                case Type<MetadataViews.NFTCollectionData>():
+                    return MetadataViews.NFTCollectionData(
+                        storagePath: ExampleNFT.CollectionStoragePath,
+                        publicPath: ExampleNFT.CollectionPublicPath,
+                        providerPath: /private/exampleNFTCollection,
+                        publicCollection: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>(),
+                        publicLinkedType: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(),
+                        providerLinkedType: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Provider,MetadataViews.ResolverCollection}>(),
+                        createEmptyCollectionFunction: (fun (): @NonFungibleToken.Collection {
+                            return <-ExampleNFT.createEmptyCollection()
+                        })
                     )
             }
             return nil

--- a/cadence/contracts/MetadataViews.cdc
+++ b/cadence/contracts/MetadataViews.cdc
@@ -11,7 +11,8 @@ a different kind of metadata, such as a creator biography
 or a JPEG image file.
 */
 
-import FungibleToken from "./FungibleToken.cdc"
+import FungibleToken from "./utility/FungibleToken.cdc"
+import NonFungibleToken from "./NonFungibleToken.cdc"
 
 pub contract MetadataViews {
 
@@ -236,6 +237,65 @@ pub contract MetadataViews {
 
         init(_ url: String) {
             self.url=url
+        }
+    }
+
+
+    // A view to expose the information needed store and retrieve an NFT
+    //
+    // This can be used by applications to setup a NFT collection with proper storage and public capabilities.
+    pub struct NFTCollectionData {
+        // Path in storage where this NFT is recommended to be stored.
+        pub let storagePath: StoragePath
+
+        // Public path which must be linked to expose public capabilities of this NFT
+        // including standard NFT interfaces and metadataviews interfaces
+        pub let publicPath: PublicPath
+
+        // Private path which should be linked to expose the provider
+        // capability to withdraw NFTs from the collection holding NFTs
+        pub let providerPath: PrivatePath
+
+        // Public collection type that is expected to provide sufficient read-only access to standard
+        // functions (deposit + getIDs + borrowNFT)
+        // This field is for backwards compatibility with collections that have not used the standard
+        // NonFungibleToken.CollectionPublic interface when setting up collections. For new
+        // collections, this may be set to be equal to the type specified in `publicLinkedType`.
+        pub let publicCollection: Type
+
+        // Type that should be linked at the aforementioned public path. This is normally a
+        // restricted type with many interfaces. Notably the `NFT.CollectionPublic`,
+        // `NFT.Receiver`, and `MetadataViews.ResolverCollection` interfaces are required.
+        pub let publicLinkedType: Type
+
+        // Type that should be linked at the aforementioned private path. This is normally
+        // a restricted type with at a minimum the `NFT.Provider` interface
+        pub let providerLinkedType: Type
+
+        // Function that allows creation of an empty NFT collection that is intended to store
+        // this NFT.
+        pub let createEmptyCollection: ((): @NonFungibleToken.Collection)
+
+        init(
+            storagePath: StoragePath,
+            publicPath: PublicPath,
+            providerPath: PrivatePath,
+            publicCollection: Type,
+            publicLinkedType: Type,
+            providerLinkedType: Type,
+            createEmptyCollectionFunction: ((): @NonFungibleToken.Collection)
+        ) {
+            pre {
+                publicLinkedType.isSubtype(of: Type<&{NonFungibleToken.CollectionPublic, NonFungibleToken.Receiver, MetadataViews.ResolverCollection}>()): "Public type must include NonFungibleToken.CollectionPublic, NonFungibleToken.Receiver, and MetadataViews.ResolverCollection interfaces."
+                providerLinkedType.isSubtype(of: Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>()): "Provider type must include NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, and MetadataViews.ResolverCollection interface."
+            }
+            self.storagePath=storagePath
+            self.publicPath=publicPath
+            self.providerPath = providerPath
+            self.publicCollection=publicCollection
+            self.publicLinkedType=publicLinkedType
+            self.providerLinkedType = providerLinkedType
+            self.createEmptyCollection=createEmptyCollectionFunction
         }
     }
 }

--- a/cadence/contracts/NFTCatalog.cdc
+++ b/cadence/contracts/NFTCatalog.cdc
@@ -1,6 +1,6 @@
 pub contract NFTCatalog {
 
-  pub event EntryAdded(name : String, contractName : String, address : Address, storagePath: StoragePath, publicPath: PublicPath)
+  pub event EntryAdded(name : String, contractName : String, address : Address, nftType : Type, storagePath: StoragePath, publicPath: PublicPath)
 
   pub event ProposalEntryAdded(proposalID : UInt64, message: String, status: String)
   
@@ -31,11 +31,13 @@ pub contract NFTCatalog {
     
     pub let contractName : String
     pub let address : Address
+    pub let nftType: Type
     pub let collectionData: NFTCollectionView
 
-    init (contractName : String, address : Address, collectionData : NFTCollectionView) {
+    init (contractName : String, address : Address, nftType: Type, collectionData : NFTCollectionView) {
       self.contractName = contractName
       self.address = address
+      self.nftType = nftType
       self.collectionData = collectionData
     }
   }
@@ -101,7 +103,7 @@ pub contract NFTCatalog {
 
     self.catalog[name] = metadata
 
-    emit EntryAdded(name : name, contractName : metadata.collectionMetadata.contractName, address : metadata.collectionMetadata.address, storagePath: metadata.collectionMetadata.collectionData.storagePath, publicPath: metadata.collectionMetadata.collectionData.publicPath)
+    emit EntryAdded(name : name, contractName : metadata.collectionMetadata.contractName, address : metadata.collectionMetadata.address, nftType: metadata.collectionMetadata.nftType, storagePath: metadata.collectionMetadata.collectionData.storagePath, publicPath: metadata.collectionMetadata.collectionData.publicPath)
   }
 
   access(account) fun updateCatalogProposal(proposalID: UInt64, proposalMetadata : NFTCatalogProposal) {

--- a/cadence/scripts/get_examplenft_type.cdc
+++ b/cadence/scripts/get_examplenft_type.cdc
@@ -1,0 +1,6 @@
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
+
+pub fun main(): String {
+    return Type<@ExampleNFT.NFT>().identifier
+}

--- a/cadence/transactions/add_to_nft_catalog.cdc
+++ b/cadence/transactions/add_to_nft_catalog.cdc
@@ -5,6 +5,7 @@ transaction(
   name : String,
   contractName: String,
   address: Address,
+  nftTypeIdentifer: String,
   storagePathIdentifier: String,
   publicPathIdentifier: String
 ) {
@@ -23,6 +24,7 @@ transaction(
     let collectionMetadata = NFTCatalog.NFTCollectionMetadata(
       contractName: contractName,
       address: address,
+      nftType: CompositeType(nftTypeIdentifer)!,
       collectionData: collectionView
     )
 

--- a/cadence/transactions/add_to_nft_catalog_admin.cdc
+++ b/cadence/transactions/add_to_nft_catalog_admin.cdc
@@ -5,6 +5,7 @@ transaction(
   name : String,
   contractName: String,
   address: Address,
+  nftTypeIdentifer: String,
   storagePathIdentifier: String,
   publicPathIdentifier: String
 ) {
@@ -24,7 +25,8 @@ transaction(
     let collectionMetadata = NFTCatalog.NFTCollectionMetadata(
       contractName: contractName,
       address: address,
-      collectionData: collectionView
+      nftType: CompositeType(nftTypeIdentifer)!,
+      collectionData: collectionView,
     )
 
     let catalogData = NFTCatalog.NFTCatalogMetadata(name: name, collectionMetadata: collectionMetadata)

--- a/cadence/transactions/propose_nft_to_catalog.cdc
+++ b/cadence/transactions/propose_nft_to_catalog.cdc
@@ -4,6 +4,7 @@ transaction(
   name : String,
   contractName: String,
   address: Address,
+  nftTypeIdentifer: String,
   storagePathIdentifier: String,
   publicPathIdentifier: String,
   message: String
@@ -20,6 +21,7 @@ transaction(
     let collectionMetadata = NFTCatalog.NFTCollectionMetadata(
       contractName: contractName,
       address: address,
+      nftType: CompositeType(nftTypeIdentifer)!,
       collectionData: collectionView
     )
 


### PR DESCRIPTION
This PR.. 

1. Updates the ExampleNFT and MetadataViews resolver
2. Stores the type of the NFT resource in the catalog

**Test Plan** : Updated test and confirmed everything still passes