### PR TITLE
Initial Implementation of NFT Retrieval w/ Catalog

### DIFF
--- a/cadence/__test__/src/nftviews.js
+++ b/cadence/__test__/src/nftviews.js
@@ -1,0 +1,29 @@
+import { executeScript, mintFlow, deployContractByName } from 'flow-js-testing'
+import { getAdminAddress } from './common'
+
+export const deployNFTRetrieval = async () => {
+  const NFTRetrievalAdmin = await getAdminAddress()
+  await mintFlow(NFTRetrievalAdmin, '10.0')
+  return deployContractByName({ to: NFTRetrievalAdmin, name: 'NFTRetrieval' })
+}
+
+export const getAllNFTsInAccount = async (ownerAddress) => {
+  const name = 'get_all_nfts_in_account';
+  const args = [ownerAddress];
+
+  return executeScript({ name, args });
+}
+
+export const getNFTsInAccount = async (ownerAddress, collections) => {
+  const name = 'get_nfts_in_account';
+  const args = [ownerAddress, collections];
+
+  return executeScript({ name, args });
+}
+
+export const getNFTInAccount = async (ownerAddress, collection, tokenID) => {
+  const name = 'get_nft_in_account';
+  const args = [ownerAddress, collection, tokenID];
+
+  return executeScript({ name, args });
+}

--- a/cadence/__test__/test/nftviews.test.js
+++ b/cadence/__test__/test/nftviews.test.js
@@ -1,0 +1,155 @@
+import path from 'path';
+import {
+  emulator,
+  init,
+  shallResolve,
+  getAccountAddress,
+  shallRevert
+} from 'flow-js-testing';
+import {
+  deployNFTCatalog,
+  setupNFTCatalogAdminProxy,
+  sendAdminProxyCapability,
+  addToCatalog
+} from '../src/nftcatalog';
+import {
+  deployExampleNFT,
+  setupExampleNFTCollection,
+  mintExampleNFT,
+  getExampleNFTType
+} from '../src/examplenft';
+import { getAllNFTsInAccount, getNFTsInAccount, deployNFTRetrieval, getNFTInAccount } from '../src/nftviews';
+
+
+describe('NFT Retrieval Test Suite', () => {
+  beforeEach(async () => {
+    const basePath = path.resolve(__dirname, '../../');
+    const port = 7002;
+    await init(basePath, { port });
+    await emulator.start(port, false);
+    return new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  // Stop emulator, so it could be restarted
+  afterEach(async () => {
+    await emulator.stop();
+    return new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  it('should retrieve all NFTs', async () => {
+    await deployNFTCatalog();
+    const Bob = await getAccountAddress('Bob');
+    await setupNFTCatalogAdminProxy(Bob);
+    await sendAdminProxyCapability(Bob)
+
+    let res = await deployExampleNFT();
+    const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
+    const Alice = await getAccountAddress('Alice');
+    await setupExampleNFTCollection(Alice)
+
+    await deployNFTRetrieval();
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+    await addToCatalog(
+      Bob,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      'exampleNFTCollection',
+      'exampleNFTCollection'
+    )
+    const nftName = 'Test Name';
+    const nftDescription = 'Test Description';
+    const thumbnail = 'https://flow.com/';
+    await mintExampleNFT(Alice, nftName, nftDescription, thumbnail, [], [], []);
+
+    const [result, error] = await shallResolve(getAllNFTsInAccount(Alice));
+    expect(error).toBe(null);
+    expect(result['ExampleNFT'][0].display.name).toBe(nftName);
+    expect(result['ExampleNFT'][0].display.description).toBe(nftDescription);
+    expect(result['ExampleNFT'][0].display.thumbnail.url).toBe(thumbnail);
+  });
+
+  it('should retrieve some NFTs', async () => {
+    await deployNFTCatalog();
+    const Bob = await getAccountAddress('Bob');
+    await setupNFTCatalogAdminProxy(Bob);
+    await sendAdminProxyCapability(Bob)
+
+    let res = await deployExampleNFT();
+    const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
+    const Alice = await getAccountAddress('Alice');
+    await setupExampleNFTCollection(Alice)
+
+    await deployNFTRetrieval();
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+    await addToCatalog(
+      Bob,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      'exampleNFTCollection',
+      'exampleNFTCollection'
+    )
+    const nftName = 'Test Name';
+    const nftDescription = 'Test Description';
+    const thumbnail = 'https://flow.com/';
+    await mintExampleNFT(Alice, nftName, nftDescription, thumbnail, [], [], []);
+
+    let [result, error] = await shallResolve(getNFTsInAccount(Alice, ['ExampleNFT']));
+    expect(result['ExampleNFT'][0].display.name).toBe(nftName);
+    expect(result['ExampleNFT'][0].display.description).toBe(nftDescription);
+    expect(result['ExampleNFT'][0].display.thumbnail.url).toBe(thumbnail);
+    expect(error).toBe(null);
+
+    [result, error] = await shallResolve(getNFTsInAccount(Alice, []));
+    expect(Object.keys(result).length).toBe(0);
+    expect(error).toBe(null);
+
+    [result, error] = await shallResolve(getNFTsInAccount(Alice, ["NotARealNFT"]));
+    expect(Object.keys(result).length).toBe(0);
+    expect(error).toBe(null);
+  });
+
+  it('should retrieve specific NFT', async () => {
+    await deployNFTCatalog();
+    const Bob = await getAccountAddress('Bob');
+    await setupNFTCatalogAdminProxy(Bob);
+    await sendAdminProxyCapability(Bob)
+
+    let res = await deployExampleNFT();
+    const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
+    const Alice = await getAccountAddress('Alice');
+    await setupExampleNFTCollection(Alice)
+
+    await deployNFTRetrieval();
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+    await addToCatalog(
+      Bob,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      'exampleNFTCollection',
+      'exampleNFTCollection'
+    )
+    const nftName = 'Test Name';
+    const nftDescription = 'Test Description';
+    const thumbnail = 'https://flow.com/';
+    await mintExampleNFT(Alice, nftName, nftDescription, thumbnail, [], [], []);
+
+    await shallRevert(getNFTInAccount(Alice, 'ExampleNFT2', 0));
+    await shallRevert(getNFTInAccount(Bob, 'ExampleNFT', 0));
+    await shallRevert(getNFTInAccount(Alice, 'ExampleNFT', 1));
+
+    const [result, error] = await shallResolve(getNFTInAccount(Alice, 'ExampleNFT', 0))
+    expect(result.display.name).toBe(nftName);
+    expect(result.display.description).toBe(nftDescription);
+    expect(result.display.thumbnail.url).toBe(thumbnail);
+    expect(error).toBe(null);
+  });
+});

--- a/cadence/contracts/MetadataViews.cdc
+++ b/cadence/contracts/MetadataViews.cdc
@@ -11,7 +11,7 @@ a different kind of metadata, such as a creator biography
 or a JPEG image file.
 */
 
-import FungibleToken from "./utility/FungibleToken.cdc"
+import FungibleToken from "./FungibleToken.cdc"
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
 pub contract MetadataViews {

--- a/cadence/contracts/NFTRetrieval.cdc
+++ b/cadence/contracts/NFTRetrieval.cdc
@@ -1,0 +1,68 @@
+import MetadataViews from "./MetadataViews.cdc"
+import NFTCatalog from "./NFTCatalog.cdc"
+
+pub contract NFTRetrieval {
+
+  pub struct BaseNFTViewsV1 {
+    pub let id: UInt64
+    pub let display: MetadataViews.Display?
+    pub let externalURL: MetadataViews.ExternalURL?
+
+    init(
+      id : UInt64,
+      display : MetadataViews.Display?,
+      externalURL : MetadataViews.ExternalURL?
+    ) {
+      self.id = id
+      self.display = display
+      self.externalURL = externalURL
+    }
+  }
+
+  pub fun getRecommendedViewsTypes(version: String) : [Type] {
+    switch version {
+      case "v1":
+        return [Type<MetadataViews.Display>(), Type<MetadataViews.ExternalURL>()]
+      default:
+        panic("Version not supported")
+    } 
+    return []
+  }
+
+  pub fun getNFTs(ownerAddress : Address) : {String : [BaseNFTViewsV1] } {
+    let catalog = NFTCatalog.getCatalog()
+
+    let ownedNFTs : { String : [BaseNFTViewsV1] } = {}
+
+    let account = getAccount(ownerAddress)
+    
+    for key in catalog.keys {
+      let items : [BaseNFTViewsV1] = []
+      let value = catalog[key]!
+      // Get users collection
+      let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(value.collectionMetadata.collectionData.publicPath)
+      if collectionCap.check() {
+        let collectionRef = collectionCap.borrow()!
+        for id in collectionRef.getIDs() {
+          let nftResolver = collectionRef.borrowViewResolver(id: id)
+          let nftViews = self.getBasedNFTViewsV1(id: id, nftResolver: nftResolver)
+          items.append(nftViews)
+        }
+      }
+      ownedNFTs[key] = items
+    }
+
+    return ownedNFTs
+  }
+
+  access(contract) fun getBasedNFTViewsV1(id : UInt64, nftResolver : &AnyResource{MetadataViews.Resolver}) : BaseNFTViewsV1 {
+    return BaseNFTViewsV1(
+      id : id,
+      display: nftResolver.resolveView(Type<MetadataViews.Display>()) as! MetadataViews.Display?,
+      externalURL : nftResolver.resolveView(Type<MetadataViews.ExternalURL>()) as! MetadataViews.ExternalURL?
+    )
+  }
+
+  init() {}
+
+}

--- a/cadence/scripts/get_all_nfts_in_account.cdc
+++ b/cadence/scripts/get_all_nfts_in_account.cdc
@@ -1,0 +1,5 @@
+import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
+
+pub fun main(ownerAddress: Address) : { String : [NFTRetrieval.BaseNFTViewsV1] } {
+  return NFTRetrieval.getNFTs(ownerAddress : ownerAddress)
+}

--- a/cadence/scripts/get_nft_in_account.cdc
+++ b/cadence/scripts/get_nft_in_account.cdc
@@ -1,0 +1,15 @@
+import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
+
+pub fun main(ownerAddress: Address, collection : String, tokenID: UInt64) : NFTRetrieval.BaseNFTViewsV1? {
+    let allNFTs = NFTRetrieval.getNFTs(ownerAddress : ownerAddress)
+
+    assert(allNFTs.containsKey(collection), message: "Invalid Collection")
+    let nfts = allNFTs[collection]!
+    
+    for nft in nfts {
+      if nft.id == tokenID {
+        return nft
+      }
+    }
+    panic("Invalid Token ID")
+}

--- a/cadence/scripts/get_nfts_in_account.cdc
+++ b/cadence/scripts/get_nfts_in_account.cdc
@@ -1,0 +1,15 @@
+import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
+
+pub fun main(ownerAddress: Address, collections: [String]) : { String : [NFTRetrieval.BaseNFTViewsV1] }  {
+  let nfts = NFTRetrieval.getNFTs(ownerAddress : ownerAddress)
+  
+  let items : {String : [NFTRetrieval.BaseNFTViewsV1] } = {}
+
+  for collection in collections {
+    if nfts.containsKey(collection) {
+      items[collection] = nfts[collection]!
+    }
+  }
+
+  return items
+}

--- a/cadence/transactions/setup_examplenft_collection.cdc
+++ b/cadence/transactions/setup_examplenft_collection.cdc
@@ -1,5 +1,6 @@
 import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
 import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import MetadataViews from "../contracts/MetadataViews.cdc"
 
 // This transaction is what an account would run
 // to set itself up to receive NFTs
@@ -19,7 +20,7 @@ transaction {
         signer.save(<-collection, to: ExampleNFT.CollectionStoragePath)
 
         // create a public capability for the collection
-        signer.link<&{NonFungibleToken.CollectionPublic, ExampleNFT.ExampleNFTCollectionPublic}>(
+        signer.link<&{NonFungibleToken.CollectionPublic, ExampleNFT.ExampleNFTCollectionPublic, MetadataViews.ResolverCollection}>(
             ExampleNFT.CollectionPublicPath,
             target: ExampleNFT.CollectionStoragePath
         )


### PR DESCRIPTION
**Summary**

This is the initial version of the contract that leverages the catalog to get NFTs in a user's account. It also includes transactions that let you

1. Get all NFTs in an account
2. Get specific NFT in account
3. Get NFTs of certain types in an account


**Test Plan**
Wrote test cases leveraging all three new transactions which talk to the Smart Contract


### NOTE
The views struct is a WIP and I will add more fields in the future. This is to show how it works.