### PR TITLE
Use Authorization to store proposer's address

### DIFF
--- a/cadence/__test__/src/nftcatalog.js
+++ b/cadence/__test__/src/nftcatalog.js
@@ -53,6 +53,14 @@ export const proposeNFTToCatalog = async (account, nftName, contractName, nftAdd
   return sendTransaction({ name, args, signers });
 }
 
+export const withdrawNFTProposalFromCatalog = async(account, proposalID) => {
+  const name = 'withdraw_nft_proposal_from_catalog';
+  const args = [proposalID];
+  const signers = [account];
+  
+  return sendTransaction({ name, args, signers });
+}
+
 export const approveNFTProposal = async (account, proposalID) => {
   const name = 'approve_nft_catalog_proposal';
   const args = [proposalID];

--- a/cadence/contracts/NFTCatalogAdmin.cdc
+++ b/cadence/contracts/NFTCatalogAdmin.cdc
@@ -21,7 +21,7 @@ pub contract NFTCatalogAdmin {
         NFTCatalog.getCatalogEntry(name : NFTCatalog.getCatalogProposalEntry(proposalID : proposalID)!.metadata.name) == nil : "The nft name has already been added to the catalog"
       }
       let catalogProposalEntry = NFTCatalog.getCatalogProposalEntry(proposalID : proposalID)!
-      let newCatalogProposalEntry = NFTCatalog.NFTCatalogProposal(metadata : catalogProposalEntry.metadata, message : catalogProposalEntry.message, status: "APPROVED")
+      let newCatalogProposalEntry = NFTCatalog.NFTCatalogProposal(metadata : catalogProposalEntry.metadata, message : catalogProposalEntry.message, status: "APPROVED", proposer: catalogProposalEntry.proposer)
       NFTCatalog.updateCatalogProposal(proposalID : proposalID, proposalMetadata : newCatalogProposalEntry)
 
       // Add to catalog
@@ -34,7 +34,7 @@ pub contract NFTCatalogAdmin {
         NFTCatalog.getCatalogProposalEntry(proposalID : proposalID)!.status == "IN_REVIEW" : "Invalid Proposal"
       }
       let catalogProposalEntry = NFTCatalog.getCatalogProposalEntry(proposalID : proposalID)!
-      let newCatalogProposalEntry = NFTCatalog.NFTCatalogProposal(metadata : catalogProposalEntry.metadata, message : catalogProposalEntry.message, status: "REJECTED")
+      let newCatalogProposalEntry = NFTCatalog.NFTCatalogProposal(metadata : catalogProposalEntry.metadata, message : catalogProposalEntry.message, status: "REJECTED", proposer: catalogProposalEntry.proposer)
       NFTCatalog.updateCatalogProposal(proposalID : proposalID, proposalMetadata : newCatalogProposalEntry)
     }
 

--- a/cadence/transactions/withdraw_nft_proposal_from_catalog.cdc
+++ b/cadence/transactions/withdraw_nft_proposal_from_catalog.cdc
@@ -1,0 +1,19 @@
+import NFTCatalog from "../contracts/NFTCatalog.cdc"
+
+transaction(
+  proposalID : UInt64
+) {
+  let nftCatalogProposalResourceRef : &NFTCatalog.NFTCatalogProposalManager
+
+  prepare(acct: AuthAccount) {
+    self.nftCatalogProposalResourceRef = acct.borrow<&NFTCatalog.NFTCatalogProposalManager>(from: NFTCatalog.ProposalManagerStoragePath)!
+  }
+
+  execute {
+    let proposal = NFTCatalog.getCatalogProposalEntry(proposalID: proposalID)!
+    
+    self.nftCatalogProposalResourceRef.setCurrentProposalEntry(name : proposal.metadata.name)
+    NFTCatalog.withdrawNFTProposal(proposalID : proposalID)
+    self.nftCatalogProposalResourceRef.setCurrentProposalEntry(name : nil)
+  }
+}


### PR DESCRIPTION
**Summary**

We want to store the account that is making a proposal to the catalog. In order to prove a user owns an address and the we use an auth model that involves the user authorizing and update to a managed resource.  This diff includes..

1. New Proposal Manager resource used for authz
2. Use manager to validate address and store address in NFTCatalog proposals.
3. Add ability for proposer to withdraw a proposal.(leverages new authz method)
4. Updates to propose cadence transaction
5. Withdraw cadence transaction


**Test Plan**
Added new test case for withdraw and confirmed old test cases still pass. Tried withdrawing from a separate account, as well.