### PR TITLE
Add nft type storage view

### DIFF
--- a/cadence/__test__/src/nftcatalog.js
+++ b/cadence/__test__/src/nftcatalog.js
@@ -29,6 +29,25 @@ export const addToCatalog = async (proxyAccount, collectionName, contractName, c
   return sendTransaction({ name, args, signers });
 }
 
+export const removeFromNFTCatalog = async (proxyAccount, collectionName) => {
+  const name = 'remove_from_nft_catalog';
+
+  const signers = [proxyAccount];
+
+  const args = [collectionName];
+
+  return sendTransaction({ name, args, signers });
+}
+
+export const updateNFTCatalogEntry = async (proxyAccount, collectionName, contractName, contractAddress, nftTypeIdentifier, addressWithNFT, nftID, publicPathIdentifier) => {
+  const name = 'update_nft_catalog_entry';
+
+  const signers = [proxyAccount];
+  const args = [collectionName, contractName, contractAddress, nftTypeIdentifier, addressWithNFT, nftID, publicPathIdentifier];
+
+  return sendTransaction({ name, args, signers });
+}
+
 export const setupNFTCatalogAdminProxy = async (account) => {
   const name = 'setup_nft_catalog_admin_proxy';
   const signers = [account];
@@ -90,6 +109,13 @@ export const removeNFTProposal = async (account, proposalID) => {
 export const getNFTMetadataForCollectionName = async (collectionName) => {
   const name = 'get_nft_metadata_for_collection_name';
   const args = [collectionName];
+
+  return executeScript({ name, args });
+}
+
+export const getNFTCollectionsForNFTType = async (nftTypeIdentifier) => {
+  const name = 'get_nft_collections_for_nft_type';
+  const args = [nftTypeIdentifier];
 
   return executeScript({ name, args });
 }

--- a/cadence/__test__/test/nftcatalog.test.js
+++ b/cadence/__test__/test/nftcatalog.test.js
@@ -19,7 +19,10 @@ import {
   approveNFTProposal,
   rejectNFTProposal,
   removeNFTProposal,
-  withdrawNFTProposalFromCatalog
+  withdrawNFTProposalFromCatalog,
+  getNFTCollectionsForNFTType,
+  removeFromNFTCatalog,
+  updateNFTCatalogEntry
 } from '../src/nftcatalog';
 import {
   deployExampleNFT,
@@ -81,6 +84,215 @@ describe('NFT Catalog Test Suite', () => {
     expect(result).not.toBe(null);
     expect(result.contractName).toBe(nftCreationEvent.data.contract);
     expect(error).toBe(null);
+  });
+
+  it('should add to catalog with two collections in a single type', async () => {
+    await deployNFTCatalog();
+
+    let res = await deployExampleNFT();
+    const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
+    const Alice = await getAccountAddress('Alice');
+    await setupExampleNFTCollection(Alice);
+    await shallPass(mintExampleNFT(Alice, TEST_NFT_NAME, TEST_NFT_DESCRIPTION, TEST_NFT_THUMBNAIL, [], [], []));
+
+
+    await shallPass(addToCatalogAdmin(
+      'ExampleNFT1',
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection',
+    ));
+
+    await shallRevert(addToCatalogAdmin(
+      'ExampleNFT1',
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection',
+    ));
+
+    await shallPass(addToCatalogAdmin(
+      'ExampleNFT2',
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection',
+    ));
+
+    let [result, error] = await shallResolve(getNFTCollectionsForNFTType(nftTypeIdentifier));
+    expect(Object.keys(result).length).toBe(2);
+    expect(result['ExampleNFT1']).not.toBe(null);
+    expect(result['ExampleNFT2']).not.toBe(null);
+    expect(error).toBe(null);
+  });
+
+  it('should remove from catalog', async () => {
+    await deployNFTCatalog();
+
+    const Alice = await getAccountAddress('Alice');
+
+    await shallResolve(setupNFTCatalogAdminProxy(Alice));
+
+    await shallResolve(sendAdminProxyCapability(Alice));
+
+    let res = await deployExampleNFT();
+    const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
+    await setupExampleNFTCollection(Alice);
+    await shallPass(mintExampleNFT(Alice, TEST_NFT_NAME, TEST_NFT_DESCRIPTION, TEST_NFT_THUMBNAIL, [], [], []));
+
+    await shallPass(addToCatalog(
+      Alice,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection'
+    ));
+
+    await shallPass(removeFromNFTCatalog(
+      Alice,
+      nftCreationEvent.data.contract
+    ));
+
+    let [result, error] = await shallResolve(getNFTCollectionsForNFTType(nftTypeIdentifier));
+    expect(result).toBe(null);
+
+    [result, error] = await shallResolve(getNFTMetadataForCollectionName('ExampleNFT'));
+    expect(result).toBe(null);
+
+    await shallPass(addToCatalog(
+      Alice,
+      'ExampleNFT1',
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection'
+    ));
+
+    await shallPass(addToCatalog(
+      Alice,
+      'ExampleNFT2',
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection'
+    ));
+
+    await shallPass(removeFromNFTCatalog(
+      Alice,
+      'ExampleNFT1'
+    ));
+
+    [result, error] = await shallResolve(getNFTCollectionsForNFTType(nftTypeIdentifier));
+    expect(Object.keys(result).length).toBe(1);
+    expect(result['ExampleNFT2']).not.toBe(null);
+
+
+    [result, error] = await shallResolve(getNFTMetadataForCollectionName('ExampleNFT1'));
+    expect(result).toBe(null);
+
+    await shallPass(removeFromNFTCatalog(
+      Alice,
+      'ExampleNFT2'
+    ));
+
+    [result, error] = await shallResolve(getNFTCollectionsForNFTType(nftTypeIdentifier));
+    expect(result).toBe(null);
+
+
+    [result, error] = await shallResolve(getNFTMetadataForCollectionName('ExampleNFT1'));
+    expect(result).toBe(null);
+  });
+
+  it('should update catalog', async () => {
+    await deployNFTCatalog();
+
+    const Alice = await getAccountAddress('Alice');
+
+    await shallResolve(setupNFTCatalogAdminProxy(Alice));
+
+    await shallResolve(sendAdminProxyCapability(Alice));
+
+    let res = await deployExampleNFT();
+    const nftCreationEvent = res[0].events.find(element => element.type === 'flow.AccountContractAdded');
+
+    const [nftTypeIdentifier, _] = await getExampleNFTType();
+
+    await setupExampleNFTCollection(Alice);
+    await shallPass(mintExampleNFT(Alice, TEST_NFT_NAME, TEST_NFT_DESCRIPTION, TEST_NFT_THUMBNAIL, [], [], []));
+
+    await shallPass(addToCatalog(
+      Alice,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.contract,
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection'
+    ));
+
+
+    await shallPass(updateNFTCatalogEntry(
+      Alice,
+      nftCreationEvent.data.contract,
+      'ExampleNFT2',
+      nftCreationEvent.data.address,
+      nftTypeIdentifier,
+      Alice,
+      0,
+      'exampleNFTCollection'
+    ));
+
+    let [result, error] = await shallResolve(getNFTCollectionsForNFTType(nftTypeIdentifier));
+    expect(Object.keys(result).length).toBe(1);
+    expect(result[nftCreationEvent.data.contract]).not.toBe(null);
+
+    [result, error] = await shallResolve(getNFTMetadataForCollectionName(nftCreationEvent.data.contract));
+    expect(result.contractName).toBe('ExampleNFT2');
+
+    const tempNewIdentifer = nftTypeIdentifier.replace('.NFT', '.Collection'); // hacky way to test another type
+
+    await shallPass(updateNFTCatalogEntry(
+      Alice,
+      nftCreationEvent.data.contract,
+      'ExampleNFT2',
+      nftCreationEvent.data.address,
+      tempNewIdentifer,
+      Alice,
+      0,
+      'exampleNFTCollection'
+    ));
+
+    [result, error] = await shallResolve(getNFTCollectionsForNFTType(nftTypeIdentifier));
+    expect(result).toBe(null);
+
+    [result, error] = await shallResolve(getNFTCollectionsForNFTType(tempNewIdentifer));
+    expect(Object.keys(result).length).toBe(1);
+    expect(result[nftCreationEvent.data.contract]).not.toBe(null);
+
+    [result, error] = await shallResolve(getNFTMetadataForCollectionName(nftCreationEvent.data.contract));
+    expect(result.contractName).toBe('ExampleNFT2');
+    expect(result.nftType.typeID).toBe(tempNewIdentifer);
   });
 
   it('non-admin accounts should be able to receive admin capability', async () => {

--- a/cadence/scripts/get_nft_collections_for_nft_type.cdc
+++ b/cadence/scripts/get_nft_collections_for_nft_type.cdc
@@ -1,0 +1,5 @@
+import NFTCatalog from "../contracts/NFTCatalog.cdc"
+
+pub fun main(nftTypeIdentifer: String): {String : Bool}? {
+  return NFTCatalog.getCollectionsForType(nftType: CompositeType(nftTypeIdentifer)!)
+}

--- a/cadence/transactions/remove_from_nft_catalog.cdc
+++ b/cadence/transactions/remove_from_nft_catalog.cdc
@@ -1,0 +1,17 @@
+import MetadataViews from "../contracts/MetadataViews.cdc"
+import NFTCatalog from "../contracts/NFTCatalog.cdc"
+import NFTCatalogAdmin from "../contracts/NFTCatalogAdmin.cdc"
+
+transaction(
+  collectionName : String
+) {
+  let adminProxyResource : &NFTCatalogAdmin.AdminProxy
+
+  prepare(acct: AuthAccount) {
+    self.adminProxyResource = acct.borrow<&NFTCatalogAdmin.AdminProxy>(from : NFTCatalogAdmin.AdminProxyStoragePath)!
+  }
+
+  execute {   
+    self.adminProxyResource.getCapability()!.borrow()!.removeCatalogEntry(collectionName : collectionName)
+  }
+}

--- a/cadence/transactions/update_nft_catalog_entry.cdc
+++ b/cadence/transactions/update_nft_catalog_entry.cdc
@@ -1,0 +1,48 @@
+import MetadataViews from "../contracts/MetadataViews.cdc"
+import NFTCatalog from "../contracts/NFTCatalog.cdc"
+import NFTCatalogAdmin from "../contracts/NFTCatalogAdmin.cdc"
+
+transaction(
+  collectionName : String,
+  contractName: String,
+  contractAddress: Address,
+  nftTypeIdentifer: String,
+  addressWithNFT: Address,
+  nftID: UInt64,
+  publicPathIdentifier: String
+) {
+  let adminProxyResource : &NFTCatalogAdmin.AdminProxy
+
+  prepare(acct: AuthAccount) {
+    self.adminProxyResource = acct.borrow<&NFTCatalogAdmin.AdminProxy>(from : NFTCatalogAdmin.AdminProxyStoragePath)!
+  }
+
+  execute {
+    let nftAccount = getAccount(addressWithNFT)
+    let pubPath = PublicPath(identifier: publicPathIdentifier)!
+    let collectionRef = nftAccount.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(pubPath).borrow() ?? panic("Invalid NFT data")
+    let nftResolver = collectionRef.borrowViewResolver(id: nftID)
+    
+    let metadataCollectionData = nftResolver.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+    
+    let collectionData = NFTCatalog.NFTCollectionData(
+      storagePath: metadataCollectionData.storagePath,
+      publicPath: metadataCollectionData.publicPath,
+      privatePath: metadataCollectionData.providerPath,
+      publicLinkedType : metadataCollectionData.publicLinkedType,
+      privateLinkedType : metadataCollectionData.providerLinkedType
+    )
+
+    let collectionDisplay = nftResolver.resolveView(Type<MetadataViews.NFTCollectionDisplay>())! as! MetadataViews.NFTCollectionDisplay
+
+    let catalogData = NFTCatalog.NFTCatalogMetadata(
+      contractName: contractName,
+      contractAddress: contractAddress,
+      nftType: CompositeType(nftTypeIdentifer)!,
+      collectionData: collectionData,
+      collectionDisplay : collectionDisplay
+    )
+    
+    self.adminProxyResource.getCapability()!.borrow()!.updateCatalogEntry(collectionName : collectionName, metadata : catalogData)
+  }
+}


### PR DESCRIPTION
**Summary**

This adds an additional storage view for catalog data to the NFT catalog. Mainly being

NFT Type -> {Collection Name : Metadata}

**Test Plan**

Confirmed old tests still pass and added new test cases for removal and additions to the catalog.