### PR TITLE
Change type key from type to string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on: pull_request
 
 jobs:
   tests:
+    env:
+      CATALOG_TESTNET_PRIVATE_KEY: ${{ secrets.CATALOG_TESTNET_PRIVATE_KEY }}
     runs-on: ubuntu-latest
     steps:
       - name: Install Node

--- a/cadence/contracts/NFTCatalog.cdc
+++ b/cadence/contracts/NFTCatalog.cdc
@@ -46,7 +46,7 @@ pub contract NFTCatalog {
 
   
   access(self) let catalog: {String : NFTCatalog.NFTCatalogMetadata}
-  access(self) let catalogTypeData: {Type : {String : Bool}}
+  access(self) let catalogTypeData: {String : {String : Bool}}
 
   access(self) let catalogProposals : {UInt64 : NFTCatalogProposal}
 
@@ -137,11 +137,11 @@ pub contract NFTCatalog {
     return self.catalog[collectionName]
   }
 
-  pub fun getCollectionsForType(nftType: Type) : {String : Bool}? {
-    return self.catalogTypeData[nftType]
+  pub fun getCollectionsForType(nftTypeIdentifier: String) : {String : Bool}? {
+    return self.catalogTypeData[nftTypeIdentifier]
   }
 
-  pub fun getCatalogTypeData() : {Type : {String : Bool}} {
+  pub fun getCatalogTypeData() : {String : {String : Bool}} {
     return self.catalogTypeData
   }
 
@@ -273,26 +273,26 @@ pub contract NFTCatalog {
   }
 
   access(contract) fun addCatalogTypeEntry(collectionName : String , metadata: NFTCatalogMetadata) {
-    if self.catalogTypeData[metadata.nftType] != nil {
-      let typeData : {String : Bool} = self.catalogTypeData[metadata.nftType]!
-      assert(self.catalogTypeData[metadata.nftType]![collectionName] == nil, message : "The nft name has already been added to the catalog")
+    if self.catalogTypeData[metadata.nftType.identifier] != nil {
+      let typeData : {String : Bool} = self.catalogTypeData[metadata.nftType.identifier]!
+      assert(self.catalogTypeData[metadata.nftType.identifier]![collectionName] == nil, message : "The nft name has already been added to the catalog")
       typeData[collectionName] = true
-      self.catalogTypeData[metadata.nftType]  = typeData
+      self.catalogTypeData[metadata.nftType.identifier]  = typeData
     } else {
       let typeData : {String : Bool} = {}
       typeData[collectionName] = true
-      self.catalogTypeData[metadata.nftType]  = typeData
+      self.catalogTypeData[metadata.nftType.identifier]  = typeData
     }
   }
 
   access(contract) fun removeCatalogTypeEntry(collectionName : String , metadata: NFTCatalogMetadata) {
     let prevMetadata = self.catalog[collectionName]!
-    let prevCollectionsForType = self.catalogTypeData[prevMetadata.nftType]!
+    let prevCollectionsForType = self.catalogTypeData[prevMetadata.nftType.identifier]!
     prevCollectionsForType.remove(key : collectionName)
     if prevCollectionsForType.length == 0 {
-      self.catalogTypeData.remove(key: prevMetadata.nftType)
+      self.catalogTypeData.remove(key: prevMetadata.nftType.identifier)
     } else {
-      self.catalogTypeData[prevMetadata.nftType] = prevCollectionsForType
+      self.catalogTypeData[prevMetadata.nftType.identifier] = prevCollectionsForType
     }
   }
 

--- a/cadence/scripts/get_nft_collections_for_nft_type.cdc
+++ b/cadence/scripts/get_nft_collections_for_nft_type.cdc
@@ -1,5 +1,5 @@
 import NFTCatalog from "../contracts/NFTCatalog.cdc"
 
 pub fun main(nftTypeIdentifer: String): {String : Bool}? {
-  return NFTCatalog.getCollectionsForType(nftType: CompositeType(nftTypeIdentifer)!)
+  return NFTCatalog.getCollectionsForType(nftTypeIdentifier: CompositeType(nftTypeIdentifer)!.identifier)
 }

--- a/flow.json
+++ b/flow.json
@@ -9,7 +9,6 @@
 		"NonFungibleToken": {
 			"source": "./cadence/contracts/NonFungibleToken.cdc",
 			"aliases": {
-				"emulator": "0xf8d6e0586b0a20c7",
 				"testnet": "0x631e88ae7f1d7c20",
 				"mainnet": "0x1d7e57aa55817448"
 			}
@@ -17,7 +16,6 @@
 		"MetadataViews": {
 			"source": "./cadence/contracts/MetadataViews.cdc",
 			"aliases": {
-				"emulator": "0xf8d6e0586b0a20c7",
 				"testnet": "0x631e88ae7f1d7c20",
 				"mainnet": "0x1d7e57aa55817448"
 			}
@@ -38,7 +36,10 @@
 				"mainnet": "0x1654653399040a61"
 			}
 		},
-		"ExampleNFT": "./cadence/contracts/ExampleNFT.cdc"
+		"ExampleNFT": "./cadence/contracts/ExampleNFT.cdc",
+		"NFTCatalog": "./cadence/contracts/NFTCatalog.cdc",
+		"NFTCatalogAdmin": "./cadence/contracts/NFTCatalogAdmin.cdc",
+		"NFTRetrieval": "./cadence/contracts/NFTRetrieval.cdc"
 	},
 	"networks": {
 		"emulator": "127.0.0.1:3569",
@@ -49,6 +50,10 @@
 		"emulator-account": {
 			"address": "0xf8d6e0586b0a20c7",
 			"key": "ff735bbeae75401fbd8cd05c0b5f154038642bc226103eddc987c7e35bacb96d"
+		},
+		"testnet-account": {
+			"address": "0x0cb698d1315f5fa0",
+			"key": "$CATALOG_TESTNET_PRIVATE_KEY"
 		}
 	},
 	"deployments": {
@@ -56,9 +61,18 @@
 			"emulator-account": [
 				"NonFungibleToken",
 				"MetadataViews",
-				"ExampleNFT"
+				"ExampleNFT",
+				"NFTCatalog",
+				"NFTCatalogAdmin",
+				"NFTRetrieval"
+			]
+		},
+		"testnet": {
+			"testnet-account": [
+				"NFTCatalog",
+				"NFTCatalogAdmin",
+				"NFTRetrieval"
 			]
 		}
 	}
 }
- 


### PR DESCRIPTION
**Summary**

Had to make these changes to be able to deploy to testnet. Emulator allowed it but testnet would throw on contract deployments. Using the identifiers instead of the type as the key.

**Test Plan**
Ran test suite. Everything still passed.