### PR TITLE
Add method to get nft collection counts for an address

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,41 @@ pub fun main(): [String] {
 }
 ```
 
-**Example 3 - Retrieve all NFTs including metadata owned by an account**
+**Example 3 - Retrieve NFT collections and counts owned by an account**
+
+```swift
+import MetadataViews from 0x1d7e57aa55817448
+import NFTCatalog from 0x49a7cda3a1eecc29
+import NFTRetrieval from 0x49a7cda3a1eecc29
+
+pub fun main(ownerAddress: Address) : {String : Number} {
+    let catalog = NFTCatalog.getCatalog()
+    let account = getAuthAccount(ownerAddress)
+    let items : {String : Number} = {}
+
+    for key in catalog.keys {
+        let value = catalog[key]!
+        let tempPathStr = "catalog".concat(key)
+        let tempPublicPath = PublicPath(identifier: tempPathStr)!
+        account.link<&{MetadataViews.ResolverCollection}>(
+            tempPublicPath,
+            target: value.collectionData.storagePath
+        )
+        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+        if !collectionCap.check() {
+            continue
+        }
+        let count = NFTRetrieval.getNFTCountFromCap(collectionIdentifier : key, collectionCap : collectionCap)
+        if count != 0 {
+            items[key] = count
+        }
+    }
+
+    return items
+}
+```
+
+**Example 4 - Retrieve all NFTs including metadata owned by an account**
 
 ```swift
 import MetadataViews from 0x1d7e57aa55817448

--- a/cadence/__test__/src/nftviews.js
+++ b/cadence/__test__/src/nftviews.js
@@ -14,6 +14,13 @@ export const getAllNFTsInAccount = async (ownerAddress) => {
     return executeScript({ name, args });
 }
 
+export const getNFTsCountInAccount = async (ownerAddress) => {
+    const name = 'get_nfts_count_in_account';
+    const args = [ownerAddress];
+
+    return executeScript({ name, args });
+}
+
 export const getNFTsInAccount = async (ownerAddress, collectionIdentifiers) => {
     const name = 'get_nfts_in_account';
     const args = [ownerAddress, collectionIdentifiers];

--- a/cadence/__test__/test/nftviews.test.js
+++ b/cadence/__test__/test/nftviews.test.js
@@ -19,7 +19,7 @@ import {
     mintExampleNFT,
     getExampleNFTType
 } from '../src/examplenft';
-import { getAllNFTsInAccount, getNFTsInAccount, deployNFTRetrieval, getNFTInAccount, getNFTsInAccountFromPath, BilalTestScript } from '../src/nftviews';
+import { getAllNFTsInAccount, getNFTsInAccount, deployNFTRetrieval, getNFTInAccount, getNFTsInAccountFromPath, getNFTsCountInAccount } from '../src/nftviews';
 import { TIMEOUT } from '../src/common';
 
 jest.setTimeout(TIMEOUT);
@@ -77,6 +77,10 @@ describe('NFT Retrieval Test Suite', () => {
         expect(result['ExampleNFT'][0].name).toBe(nftName);
         expect(result['ExampleNFT'][0].description).toBe(nftDescription);
         expect(result['ExampleNFT'][0].thumbnail).toBe(thumbnail);
+
+        [result, error] = await shallResolve(getNFTsCountInAccount(Alice));
+        expect(result['ExampleNFT']).toBe(1)
+        expect(error).toBe(null);
     });
 
     it('should retrieve some NFTs', async () => {
@@ -122,6 +126,11 @@ describe('NFT Retrieval Test Suite', () => {
 
         [result, error] = await shallResolve(getNFTsInAccount(Alice, ["NotARealNFT"]));
         expect(Object.keys(result).length).toBe(0);
+        expect(error).toBe(null);
+
+        [result, error] = await shallResolve(getNFTsCountInAccount(Alice));
+        expect(result['ExampleNFT']).toBe(1)
+        expect(result['NotARealNFT'] ?? null).toBe(null)
         expect(error).toBe(null);
     });
 

--- a/cadence/scripts/get_nfts_count_in_account.cdc
+++ b/cadence/scripts/get_nfts_count_in_account.cdc
@@ -1,0 +1,29 @@
+import MetadataViews from "../contracts/MetadataViews.cdc"
+import NFTCatalog from "../contracts/NFTCatalog.cdc"
+import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
+
+pub fun main(ownerAddress: Address) : {String : Number} {
+    let catalog = NFTCatalog.getCatalog()
+    let account = getAuthAccount(ownerAddress)
+    let items : {String : Number} = {}
+
+    for key in catalog.keys {
+        let value = catalog[key]!
+        let tempPathStr = "catalog".concat(key)
+        let tempPublicPath = PublicPath(identifier: tempPathStr)!
+        account.link<&{MetadataViews.ResolverCollection}>(
+            tempPublicPath,
+            target: value.collectionData.storagePath
+        )
+        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+        if !collectionCap.check() {
+            continue
+        }
+        let count = NFTRetrieval.getNFTCountFromCap(collectionIdentifier : key, collectionCap : collectionCap)
+        if count != 0 {
+            items[key] = count
+        }
+    }
+
+    return items
+}


### PR DESCRIPTION
**Summary**
Add a helper function to get count of NFTs for a collection in an account. This way you can load data without having to return the NFTViews which includes more data.

**Test Plan**
Added additional tests and made sure previous tests still pass.