### PR TITLE
Remove whitespaces from suggested collection name

### DIFF
--- a/ui/apps/nft-portal/src/app/components/verifier/catalog-form.tsx
+++ b/ui/apps/nft-portal/src/app/components/verifier/catalog-form.tsx
@@ -36,7 +36,8 @@ export function CatalogForm({ sampleAddress, storagePath, nftID }: CatalogProps)
           return nft.Id === nftID
         })
         if (selectedNft && selectedNft.NFTCollectionDisplay) {
-          setCollectionIdentifier(selectedNft.NFTCollectionDisplay.collectionName)
+          // Get rid of spaces if they exist..
+          setCollectionIdentifier(selectedNft.NFTCollectionDisplay.collectionName.replace(/\s+/g,''))
         }
       }
     }


### PR DESCRIPTION
**Summary**
We are smart and try to infer the collection name, however the display collection name on chain can have spaces where this identifier can't. In order to fix this instead of suggesting an invalid name, we can just remove the white space(if there are any)


**Test Plan**
_Before_
![Screen Shot 2022-08-11 at 8 55 07 AM](https://user-images.githubusercontent.com/5430668/184138474-88688ee6-3ae7-4079-a34e-1f6eba17b900.png)
_After_
![Screen Shot 2022-08-11 at 8 55 12 AM](https://user-images.githubusercontent.com/5430668/184138491-a4b9133f-dbe4-4f53-968d-d668ca6ca825.png)

