### PR TITLE
Update examples in README.md file

### DIFF
--- a/cadence/scripts/get_all_nfts_and_views_in_account.cdc
+++ b/cadence/scripts/get_all_nfts_and_views_in_account.cdc
@@ -3,18 +3,18 @@ import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
 pub struct NFTCollectionData {
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
 
     init(
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
     ) {
         self.storagePath = storagePath
         self.publicPath = publicPath
@@ -24,43 +24,46 @@ pub struct NFTCollectionData {
     }
 }
 
-pub fun main(ownerAddress: Address) : { String : {String : AnyStruct} }  {
+pub fun main(ownerAddress: Address): {String: {String: AnyStruct}} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
-    let items : [MetadataViews.NFTView] = []
-    
-    let data : { String : {String : AnyStruct} } = {}
+    let items: [MetadataViews.NFTView] = []
+    let data: {String: {String: AnyStruct}} = {}
 
     for key in catalog.keys {
         let value = catalog[key]!
-        let tempPathStr = "catalog".concat(key)
+        let keyHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(key.utf8))
+        let tempPathStr = "catalog".concat(keyHash)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
         account.link<&{MetadataViews.ResolverCollection}>(
             tempPublicPath,
             target: value.collectionData.storagePath
         )
+
         let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+
         if !collectionCap.check() {
             continue
         }
-        
-        var views = NFTRetrieval.getAllMetadataViewsFromCap(collectionIdentifier : key, collectionCap : collectionCap)
-        
+
+        var views = NFTRetrieval.getAllMetadataViewsFromCap(collectionIdentifier: key, collectionCap: collectionCap)
+
         if views.keys.length == 0 {
             continue
         }
-        
+
         // Cadence doesn't support function return types, lets manually get rid of it
         let nftCollectionDisplayView = views[Type<MetadataViews.NFTCollectionData>().identifier] as! MetadataViews.NFTCollectionData?
         let collectionDataView = NFTCollectionData(
-                    storagePath : nftCollectionDisplayView!.storagePath,
-                    publicPath : nftCollectionDisplayView!.publicPath,
-                    privatePath : nftCollectionDisplayView!.providerPath,
-                    publicLinkedType : nftCollectionDisplayView!.publicLinkedType,
-                    privateLinkedType : nftCollectionDisplayView!.providerLinkedType,
+            storagePath: nftCollectionDisplayView!.storagePath,
+            publicPath: nftCollectionDisplayView!.publicPath,
+            privatePath: nftCollectionDisplayView!.providerPath,
+            publicLinkedType: nftCollectionDisplayView!.publicLinkedType,
+            privateLinkedType: nftCollectionDisplayView!.providerLinkedType,
         )
         views.insert(key: Type<MetadataViews.NFTCollectionData>().identifier, collectionDataView)
-        
+
         data[key] = views
     }
 

--- a/cadence/scripts/get_all_nfts_in_account.cdc
+++ b/cadence/scripts/get_all_nfts_in_account.cdc
@@ -3,40 +3,40 @@ import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
 pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let id: UInt64
+    pub let name: String
+    pub let description: String
+    pub let thumbnail: String
+    pub let externalURL: String
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
-    pub let collectionName : String
+    pub let collectionName: String
     pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let collectionExternalURL : String
+    pub let collectionSquareImage: String
+    pub let collectionBannerImage: String
+    pub let collectionExternalURL: String
     pub let royalties: [MetadataViews.Royalty]
 
     init(
-            id: UInt64,
-            name : String,
-            description : String,
-            thumbnail : String,
-            externalURL : String,
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
-            collectionName : String,
-            collectionDescription : String,
-            collectionSquareImage : String,
-            collectionBannerImage : String,
-            collectionExternalURL : String,
-            royalties : [MetadataViews.Royalty]
+        id: UInt64,
+        name: String,
+        description: String,
+        thumbnail: String,
+        externalURL: String,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
+        collectionName: String,
+        collectionDescription: String,
+        collectionSquareImage: String,
+        collectionBannerImage: String,
+        collectionExternalURL: String,
+        royalties: [MetadataViews.Royalty]
     ) {
         self.id = id
         self.name = name
@@ -57,34 +57,39 @@ pub struct NFT {
     }
 }
 
-pub fun main(ownerAddress: Address) : { String : [NFT] } {
+pub fun main(ownerAddress: Address): {String: [NFT]} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
-    let items : [MetadataViews.NFTView] = []
-    
-    let data : {String : [NFT] } = {}
+    let items: [MetadataViews.NFTView] = []
+    let data: {String: [NFT]} = {}
 
     for key in catalog.keys {
         let value = catalog[key]!
-        let tempPathStr = "catalog".concat(key)
+        let keyHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(key.utf8))
+        let tempPathStr = "catalog".concat(keyHash)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
         account.link<&{MetadataViews.ResolverCollection}>(
             tempPublicPath,
             target: value.collectionData.storagePath
         )
+
         let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+
         if !collectionCap.check() {
             continue
         }
-        let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier : key, collectionCap : collectionCap)
 
-        let items : [NFT] = []
+        let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier: key, collectionCap: collectionCap)
+        let items: [NFT] = []
+
         for view in views {
             let displayView = view.display
             let externalURLView = view.externalURL
             let collectionDataView = view.collectionData
             let collectionDisplayView = view.collectionDisplay
             let royaltyView = view.royalties
+
             if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
                 // Bad NFT. Skipping....
                 continue
@@ -93,25 +98,27 @@ pub fun main(ownerAddress: Address) : { String : [NFT] } {
             items.append(
                 NFT(
                     id: view.id,
-                    name : displayView!.name,
-                    description : displayView!.description,
-                    thumbnail : displayView!.thumbnail.uri(),
-                    externalURL : externalURLView!.url,
-                    storagePath : collectionDataView!.storagePath,
-                    publicPath : collectionDataView!.publicPath,
-                    privatePath : collectionDataView!.providerPath,
-                    publicLinkedType : collectionDataView!.publicLinkedType,
-                    privateLinkedType : collectionDataView!.providerLinkedType,
-                    collectionName : collectionDisplayView!.name,
-                    collectionDescription : collectionDisplayView!.description,
-                    collectionSquareImage : collectionDisplayView!.squareImage.file.uri(),
-                    collectionBannerImage : collectionDisplayView!.bannerImage.file.uri(),
-                    collectionExternalURL : collectionDisplayView!.externalURL.url,
-                    royalties : royaltyView!.getRoyalties()
+                    name: displayView!.name,
+                    description: displayView!.description,
+                    thumbnail: displayView!.thumbnail.uri(),
+                    externalURL: externalURLView!.url,
+                    storagePath: collectionDataView!.storagePath,
+                    publicPath: collectionDataView!.publicPath,
+                    privatePath: collectionDataView!.providerPath,
+                    publicLinkedType: collectionDataView!.publicLinkedType,
+                    privateLinkedType: collectionDataView!.providerLinkedType,
+                    collectionName: collectionDisplayView!.name,
+                    collectionDescription: collectionDisplayView!.description,
+                    collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+                    collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+                    collectionExternalURL: collectionDisplayView!.externalURL.url,
+                    royalties: royaltyView!.getRoyalties()
                 )
             )
         }
+
         data[key] = items
     }
+
     return data
 }

--- a/cadence/scripts/get_nft_and_views_in_account.cdc
+++ b/cadence/scripts/get_nft_and_views_in_account.cdc
@@ -1,21 +1,20 @@
-import MetadataViews from 0x1d7e57aa55817448
-import NFTCatalog from 0x49a7cda3a1eecc29
-import NFTRetrieval from 0x49a7cda3a1eecc29
-
+import MetadataViews from "../contracts/MetadataViews.cdc"
+import NFTCatalog from "../contracts/NFTCatalog.cdc"
+import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
 pub struct NFTCollectionData {
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
 
     init(
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
     ) {
         self.storagePath = storagePath
         self.publicPath = publicPath
@@ -25,44 +24,43 @@ pub struct NFTCollectionData {
     }
 }
 
-
 pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let id: UInt64
+    pub let name: String
+    pub let description: String
+    pub let thumbnail: String
+    pub let externalURL: String
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
-    pub let collectionName : String
+    pub let collectionName: String
     pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let collectionExternalURL : String
-    pub let allViews :  {String: AnyStruct}?
+    pub let collectionSquareImage: String
+    pub let collectionBannerImage: String
+    pub let collectionExternalURL: String
+    pub let allViews:  {String: AnyStruct}?
     pub let royalties: [MetadataViews.Royalty]
 
     init(
-            id: UInt64,
-            name : String,
-            description : String,
-            thumbnail : String,
-            externalURL : String,
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
-            collectionName : String,
-            collectionDescription : String,
-            collectionSquareImage : String,
-            collectionBannerImage : String,
-            collectionExternalURL : String,
-            allViews : {String: AnyStruct}?,
-            royalties : [MetadataViews.Royalty]
+        id: UInt64,
+        name: String,
+        description: String,
+        thumbnail: String,
+        externalURL: String,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
+        collectionName: String,
+        collectionDescription: String,
+        collectionSquareImage: String,
+        collectionBannerImage: String,
+        collectionExternalURL: String,
+        allViews: {String: AnyStruct}?,
+        royalties: [MetadataViews.Royalty]
     ) {
         self.id = id
         self.name = name
@@ -84,99 +82,107 @@ pub struct NFT {
     }
 }
 
- pub fun getAllMetadataViewsFromCap(tokenID: UInt64, collectionIdentifier: String, collectionCap : Capability<&AnyResource{MetadataViews.ResolverCollection}>) : {String: AnyStruct} {
-        pre {
-            NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
-        }
-        let catalog = NFTCatalog.getCatalog()
-        let items : {String: AnyStruct} = {}
-        let value = catalog[collectionIdentifier]!
-
-        // Check if we have multiple collections for the NFT type...
-        let hasMultipleCollections = false
-    
-        if collectionCap.check() {
-            let collectionRef = collectionCap.borrow()!
-
-            let nftResolver = collectionRef.borrowViewResolver(id: tokenID)
-            let supportedNftViewTypes = nftResolver.getViews()
-            for supportedViewType in supportedNftViewTypes {
-                if let view = nftResolver.resolveView(supportedViewType) {
-                    if !hasMultipleCollections {
-                        items.insert(key : supportedViewType.identifier, view)
-                    } else if MetadataViews.getDisplay(nftResolver)!.name == value.collectionDisplay.name {
-                        items.insert(key : supportedViewType.identifier, view)
-                    }
-                }
-            }
-        
-        }
-        return items
+ pub fun getAllMetadataViewsFromCap(tokenID: UInt64, collectionIdentifier: String, collectionCap: Capability<&AnyResource{MetadataViews.ResolverCollection}>): {String: AnyStruct} {
+    pre {
+        NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
     }
 
-pub fun main(ownerAddress: Address, collectionIdentifier : String, tokenID: UInt64) : NFT? {
-        let catalog = NFTCatalog.getCatalog()
+    let catalog = NFTCatalog.getCatalog()
+    let items: {String: AnyStruct} = {}
+    let value = catalog[collectionIdentifier]!
 
-        assert(catalog.containsKey(collectionIdentifier), message: "Invalid Collection")
-        
-        let account = getAuthAccount(ownerAddress)
-        
-        let value = catalog[collectionIdentifier]!
-        let tempPathStr = "catalog".concat(collectionIdentifier)
-        let tempPublicPath = PublicPath(identifier: tempPathStr)!
-        account.link<&{MetadataViews.ResolverCollection}>(
-            tempPublicPath,
-            target: value.collectionData.storagePath
-        )
-        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
-        assert(collectionCap.check(), message: "MetadataViews Collection is not set up properly, ensure the Capability was created/linked correctly.")
-        
-        let allViews = getAllMetadataViewsFromCap(tokenID: tokenID, collectionIdentifier : collectionIdentifier, collectionCap : collectionCap)
-        let nftCollectionDisplayView = allViews[Type<MetadataViews.NFTCollectionData>().identifier] as! MetadataViews.NFTCollectionData?
-        let collectionDataView = NFTCollectionData(
-                    storagePath : nftCollectionDisplayView!.storagePath,
-                    publicPath : nftCollectionDisplayView!.publicPath,
-                    privatePath : nftCollectionDisplayView!.providerPath,
-                    publicLinkedType : nftCollectionDisplayView!.publicLinkedType,
-                    privateLinkedType : nftCollectionDisplayView!.providerLinkedType,
-        )
-        
-        allViews.insert(key: Type<MetadataViews.NFTCollectionData>().identifier, collectionDataView)
+    // Check if we have multiple collections for the NFT type...
+    let hasMultipleCollections = false
 
-        let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier : collectionIdentifier, collectionCap : collectionCap)
-        
-        for view in views {
-            if view.id == tokenID {
-                let displayView = view.display
-                let externalURLView = view.externalURL
-                let collectionDataView = view.collectionData
-                let collectionDisplayView = view.collectionDisplay
-                let royaltyView = view.royalties
-                if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
-                    // Bad NFT. Skipping....
-                    return nil
+    if collectionCap.check() {
+        let collectionRef = collectionCap.borrow()!
+
+        let nftResolver = collectionRef.borrowViewResolver(id: tokenID)
+        let supportedNftViewTypes = nftResolver.getViews()
+
+        for supportedViewType in supportedNftViewTypes {
+            if let view = nftResolver.resolveView(supportedViewType) {
+                if !hasMultipleCollections {
+                    items.insert(key: supportedViewType.identifier, view)
+                } else if MetadataViews.getDisplay(nftResolver)!.name == value.collectionDisplay.name {
+                    items.insert(key: supportedViewType.identifier, view)
                 }
-                return NFT(
-                    id: view.id,
-                    name : displayView!.name,
-                    description : displayView!.description,
-                    thumbnail : displayView!.thumbnail.uri(),
-                    externalURL : externalURLView!.url,
-                    storagePath : collectionDataView!.storagePath,
-                    publicPath : collectionDataView!.publicPath,
-                    privatePath : collectionDataView!.providerPath,
-                    publicLinkedType : collectionDataView!.publicLinkedType,
-                    privateLinkedType : collectionDataView!.providerLinkedType,
-                    collectionName : collectionDisplayView!.name,
-                    collectionDescription : collectionDisplayView!.description,
-                    collectionSquareImage : collectionDisplayView!.squareImage.file.uri(),
-                    collectionBannerImage : collectionDisplayView!.bannerImage.file.uri(),
-                    collectionExternalURL : collectionDisplayView!.externalURL.url,
-                    allViews : allViews,
-                    royalties : royaltyView!.getRoyalties()
-                )
             }
         }
-        
-        panic("Invalid Token ID")
+
+    }
+
+    return items
+}
+
+pub fun main(ownerAddress: Address, collectionIdentifier: String, tokenID: UInt64) : NFT? {
+    let catalog = NFTCatalog.getCatalog()
+
+    assert(catalog.containsKey(collectionIdentifier), message: "Invalid Collection")
+
+    let account = getAuthAccount(ownerAddress)
+
+    let value = catalog[collectionIdentifier]!
+    let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
+    let tempPathStr = "catalog".concat(identifierHash)
+    let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
+    account.link<&{MetadataViews.ResolverCollection}>(
+        tempPublicPath,
+        target: value.collectionData.storagePath
+    )
+
+    let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+    assert(collectionCap.check(), message: "MetadataViews Collection is not set up properly, ensure the Capability was created/linked correctly.")
+
+    let allViews = getAllMetadataViewsFromCap(tokenID: tokenID, collectionIdentifier: collectionIdentifier, collectionCap: collectionCap)
+    let nftCollectionDisplayView = allViews[Type<MetadataViews.NFTCollectionData>().identifier] as! MetadataViews.NFTCollectionData?
+    let collectionDataView = NFTCollectionData(
+        storagePath: nftCollectionDisplayView!.storagePath,
+        publicPath: nftCollectionDisplayView!.publicPath,
+        privatePath: nftCollectionDisplayView!.providerPath,
+        publicLinkedType: nftCollectionDisplayView!.publicLinkedType,
+        privateLinkedType: nftCollectionDisplayView!.providerLinkedType,
+    )
+
+    allViews.insert(key: Type<MetadataViews.NFTCollectionData>().identifier, collectionDataView)
+
+    let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier: collectionIdentifier, collectionCap: collectionCap)
+
+    for view in views {
+        if view.id == tokenID {
+            let displayView = view.display
+            let externalURLView = view.externalURL
+            let collectionDataView = view.collectionData
+            let collectionDisplayView = view.collectionDisplay
+            let royaltyView = view.royalties
+
+            if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
+                // Bad NFT. Skipping....
+                return nil
+            }
+
+            return NFT(
+                id: view.id,
+                name: displayView!.name,
+                description: displayView!.description,
+                thumbnail: displayView!.thumbnail.uri(),
+                externalURL: externalURLView!.url,
+                storagePath: collectionDataView!.storagePath,
+                publicPath: collectionDataView!.publicPath,
+                privatePath: collectionDataView!.providerPath,
+                publicLinkedType: collectionDataView!.publicLinkedType,
+                privateLinkedType: collectionDataView!.providerLinkedType,
+                collectionName: collectionDisplayView!.name,
+                collectionDescription: collectionDisplayView!.description,
+                collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+                collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+                collectionExternalURL: collectionDisplayView!.externalURL.url,
+                allViews: allViews,
+                royalties: royaltyView!.getRoyalties()
+            )
+        }
+    }
+
+    panic("Invalid Token ID")
 }

--- a/cadence/scripts/get_nft_ids_in_account.cdc
+++ b/cadence/scripts/get_nft_ids_in_account.cdc
@@ -2,32 +2,34 @@ import MetadataViews from "../contracts/MetadataViews.cdc"
 import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
-pub fun main(ownerAddress: Address) : {String : [UInt64]} {
+pub fun main(ownerAddress: Address): {String: [UInt64]} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
-
-    let items : {String : [UInt64]} = {}
+    let items: {String: [UInt64]} = {}
 
     for key in catalog.keys {
         let value = catalog[key]!
-        let tempPathStr = "catalogIDs".concat(key)
+        let keyHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(key.utf8))
+        let tempPathStr = "catalogIDs".concat(keyHash)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
         account.link<&{MetadataViews.ResolverCollection}>(
             tempPublicPath,
             target: value.collectionData.storagePath
         )
 
         let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+
         if !collectionCap.check() {
             continue
         }
 
-        let ids = NFTRetrieval.getNFTIDsFromCap(collectionIdentifier : key, collectionCap : collectionCap)
+        let ids = NFTRetrieval.getNFTIDsFromCap(collectionIdentifier: key, collectionCap: collectionCap)
 
         if ids.length > 0 {
             items[key] = ids
         }
     }
-    return items
 
+    return items
 }

--- a/cadence/scripts/get_nft_in_account.cdc
+++ b/cadence/scripts/get_nft_in_account.cdc
@@ -3,40 +3,40 @@ import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
 pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let id: UInt64
+    pub let name: String
+    pub let description: String
+    pub let thumbnail: String
+    pub let externalURL: String
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
-    pub let collectionName : String
+    pub let collectionName: String
     pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let collectionExternalURL : String
+    pub let collectionSquareImage: String
+    pub let collectionBannerImage: String
+    pub let collectionExternalURL: String
     pub let royalties: [MetadataViews.Royalty]
 
     init(
-            id: UInt64,
-            name : String,
-            description : String,
-            thumbnail : String,
-            externalURL : String,
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
-            collectionName : String,
-            collectionDescription : String,
-            collectionSquareImage : String,
-            collectionBannerImage : String,
-            collectionExternalURL : String,
-            royalties : [MetadataViews.Royalty]
+        id: UInt64,
+        name: String,
+        description: String,
+        thumbnail: String,
+        externalURL: String,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
+        collectionName: String,
+        collectionDescription: String,
+        collectionSquareImage: String,
+        collectionBannerImage: String,
+        collectionExternalURL: String,
+        royalties: [MetadataViews.Royalty]
     ) {
         self.id = id
         self.name = name
@@ -57,54 +57,61 @@ pub struct NFT {
     }
 }
 
-pub fun main(ownerAddress: Address, collectionIdentifier : String, tokenID: UInt64) : NFT? {
-        let catalog = NFTCatalog.getCatalog()
+pub fun main(ownerAddress: Address, collectionIdentifier: String, tokenID: UInt64): NFT? {
+    let catalog = NFTCatalog.getCatalog()
 
-        assert(catalog.containsKey(collectionIdentifier), message: "Invalid Collection")
-        
-        let account = getAuthAccount(ownerAddress)
-        
-        let value = catalog[collectionIdentifier]!
-        let tempPathStr = "catalog".concat(collectionIdentifier)
-        let tempPublicPath = PublicPath(identifier: tempPathStr)!
-        account.link<&{MetadataViews.ResolverCollection}>(
-            tempPublicPath,
-            target: value.collectionData.storagePath
-        )
-        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
-        assert(collectionCap.check(), message: "MetadataViews Collection is not set up properly, ensure the Capability was created/linked correctly.")
-        let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier : collectionIdentifier, collectionCap : collectionCap)
-        
-        for view in views {
-            if view.id == tokenID {
-                let displayView = view.display
-                let externalURLView = view.externalURL
-                let collectionDataView = view.collectionData
-                let collectionDisplayView = view.collectionDisplay
-                let royaltyView = view.royalties
-                if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
-                    // Bad NFT. Skipping....
-                    return nil
-                }
-                return NFT(
-                    id: view.id,
-                    name : displayView!.name,
-                    description : displayView!.description,
-                    thumbnail : displayView!.thumbnail.uri(),
-                    externalURL : externalURLView!.url,
-                    storagePath : collectionDataView!.storagePath,
-                    publicPath : collectionDataView!.publicPath,
-                    privatePath : collectionDataView!.providerPath,
-                    publicLinkedType : collectionDataView!.publicLinkedType,
-                    privateLinkedType : collectionDataView!.providerLinkedType,
-                    collectionName : collectionDisplayView!.name,
-                    collectionDescription : collectionDisplayView!.description,
-                    collectionSquareImage : collectionDisplayView!.squareImage.file.uri(),
-                    collectionBannerImage : collectionDisplayView!.bannerImage.file.uri(),
-                    collectionExternalURL : collectionDisplayView!.externalURL.url,
-                    royalties : royaltyView!.getRoyalties()
-                )
+    assert(catalog.containsKey(collectionIdentifier), message: "Invalid Collection")
+
+    let account = getAuthAccount(ownerAddress)
+
+    let value = catalog[collectionIdentifier]!
+    let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
+    let tempPathStr = "catalog".concat(identifierHash)
+    let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
+    account.link<&{MetadataViews.ResolverCollection}>(
+        tempPublicPath,
+        target: value.collectionData.storagePath
+    )
+
+    let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+    assert(collectionCap.check(), message: "MetadataViews Collection is not set up properly, ensure the Capability was created/linked correctly.")
+
+    let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier : collectionIdentifier, collectionCap : collectionCap)
+
+    for view in views {
+        if view.id == tokenID {
+            let displayView = view.display
+            let externalURLView = view.externalURL
+            let collectionDataView = view.collectionData
+            let collectionDisplayView = view.collectionDisplay
+            let royaltyView = view.royalties
+
+            if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
+                // Bad NFT. Skipping....
+                return nil
             }
+
+            return NFT(
+                id: view.id,
+                name: displayView!.name,
+                description: displayView!.description,
+                thumbnail: displayView!.thumbnail.uri(),
+                externalURL: externalURLView!.url,
+                storagePath: collectionDataView!.storagePath,
+                publicPath: collectionDataView!.publicPath,
+                privatePath: collectionDataView!.providerPath,
+                publicLinkedType: collectionDataView!.publicLinkedType,
+                privateLinkedType: collectionDataView!.providerLinkedType,
+                collectionName: collectionDisplayView!.name,
+                collectionDescription: collectionDisplayView!.description,
+                collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+                collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+                collectionExternalURL: collectionDisplayView!.externalURL.url,
+                royalties: royaltyView!.getRoyalties()
+            )
         }
-        panic("Invalid Token ID")
+    }
+
+    panic("Invalid Token ID")
 }

--- a/cadence/scripts/get_nfts_count_in_account.cdc
+++ b/cadence/scripts/get_nfts_count_in_account.cdc
@@ -2,24 +2,30 @@ import MetadataViews from "../contracts/MetadataViews.cdc"
 import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
-pub fun main(ownerAddress: Address) : {String : Number} {
+pub fun main(ownerAddress: Address): {String: Number} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
-    let items : {String : Number} = {}
+    let items: {String: Number} = {}
 
     for key in catalog.keys {
         let value = catalog[key]!
-        let tempPathStr = "catalog".concat(key)
+        let keyHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(key.utf8))
+        let tempPathStr = "catalog".concat(keyHash)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
         account.link<&{MetadataViews.ResolverCollection}>(
             tempPublicPath,
             target: value.collectionData.storagePath
         )
+
         let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+
         if !collectionCap.check() {
             continue
         }
-        let count = NFTRetrieval.getNFTCountFromCap(collectionIdentifier : key, collectionCap : collectionCap)
+
+        let count = NFTRetrieval.getNFTCountFromCap(collectionIdentifier: key, collectionCap: collectionCap)
+
         if count != 0 {
             items[key] = count
         }

--- a/cadence/scripts/get_nfts_in_account.cdc
+++ b/cadence/scripts/get_nfts_in_account.cdc
@@ -3,40 +3,40 @@ import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
 pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let id: UInt64
+    pub let name: String
+    pub let description: String
+    pub let thumbnail: String
+    pub let externalURL: String
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
-    pub let collectionName : String
+    pub let collectionName: String
     pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let collectionExternalURL : String
+    pub let collectionSquareImage: String
+    pub let collectionBannerImage: String
+    pub let collectionExternalURL: String
     pub let royalties: [MetadataViews.Royalty]
 
     init(
-            id: UInt64,
-            name : String,
-            description : String,
-            thumbnail : String,
-            externalURL : String,
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
-            collectionName : String,
-            collectionDescription : String,
-            collectionSquareImage : String,
-            collectionBannerImage : String,
-            collectionExternalURL : String,
-            royalties : [MetadataViews.Royalty]
+        id: UInt64,
+        name: String,
+        description: String,
+        thumbnail: String,
+        externalURL: String,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
+        collectionName: String,
+        collectionDescription: String,
+        collectionSquareImage: String,
+        collectionBannerImage: String,
+        collectionExternalURL: String,
+        royalties: [MetadataViews.Royalty]
     ) {
         self.id = id
         self.name = name
@@ -57,36 +57,39 @@ pub struct NFT {
     }
 }
 
-pub fun main(ownerAddress: Address, collectionIdentifiers: [String]) : { String : [NFT] }    {
+pub fun main(ownerAddress: Address, collectionIdentifiers: [String]): {String: [NFT]} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
-    
-    let data : {String : [NFT] } = {}
+    let data: {String: [NFT]} = {}
 
     for collectionIdentifier in collectionIdentifiers {
         if catalog.containsKey(collectionIdentifier) {
             let value = catalog[collectionIdentifier]!
-            let tempPathStr = "catalog".concat(collectionIdentifier)
+            let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
+            let tempPathStr = "catalog".concat(identifierHash)
             let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
             account.link<&{MetadataViews.ResolverCollection}>(
                 tempPublicPath,
                 target: value.collectionData.storagePath
             )
-            
+
             let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+
             if !collectionCap.check() {
                 continue
             }
-            let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier : collectionIdentifier, collectionCap : collectionCap)
-            
-            let items : [NFT] = []
-            
+
+            let views = NFTRetrieval.getNFTViewsFromCap(collectionIdentifier: collectionIdentifier, collectionCap: collectionCap)
+
+            let items: [NFT] = []
             for view in views {
                 let displayView = view.display
                 let externalURLView = view.externalURL
                 let collectionDataView = view.collectionData
                 let collectionDisplayView = view.collectionDisplay
                 let royaltyView = view.royalties
+
                 if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
                     // Bad NFT. Skipping....
                     continue
@@ -95,25 +98,25 @@ pub fun main(ownerAddress: Address, collectionIdentifiers: [String]) : { String 
                 items.append(
                     NFT(
                         id: view.id,
-                        name : displayView!.name,
-                        description : displayView!.description,
-                        thumbnail : displayView!.thumbnail.uri(),
-                        externalURL : externalURLView!.url,
-                        storagePath : collectionDataView!.storagePath,
-                        publicPath : collectionDataView!.publicPath,
-                        privatePath : collectionDataView!.providerPath,
-                        publicLinkedType : collectionDataView!.publicLinkedType,
-                        privateLinkedType : collectionDataView!.providerLinkedType,
-                        collectionName : collectionDisplayView!.name,
-                        collectionDescription : collectionDisplayView!.description,
-                        collectionSquareImage : collectionDisplayView!.squareImage.file.uri(),
-                        collectionBannerImage : collectionDisplayView!.bannerImage.file.uri(),
-                        collectionExternalURL : collectionDisplayView!.externalURL.url,
-                        royalties : royaltyView!.getRoyalties()
+                        name: displayView!.name,
+                        description: displayView!.description,
+                        thumbnail: displayView!.thumbnail.uri(),
+                        externalURL: externalURLView!.url,
+                        storagePath: collectionDataView!.storagePath,
+                        publicPath: collectionDataView!.publicPath,
+                        privatePath: collectionDataView!.providerPath,
+                        publicLinkedType: collectionDataView!.publicLinkedType,
+                        privateLinkedType: collectionDataView!.providerLinkedType,
+                        collectionName: collectionDisplayView!.name,
+                        collectionDescription: collectionDisplayView!.description,
+                        collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+                        collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+                        collectionExternalURL: collectionDisplayView!.externalURL.url,
+                        royalties: royaltyView!.getRoyalties()
                     )
                 )
             }
-            
+
             data[collectionIdentifier] = items
         }
     }

--- a/cadence/scripts/get_nfts_in_account_from_ids.cdc
+++ b/cadence/scripts/get_nfts_in_account_from_ids.cdc
@@ -3,40 +3,40 @@ import NFTCatalog from "../contracts/NFTCatalog.cdc"
 import NFTRetrieval from "../contracts/NFTRetrieval.cdc"
 
 pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
+    pub let id: UInt64
+    pub let name: String
+    pub let description: String
+    pub let thumbnail: String
+    pub let externalURL: String
+    pub let storagePath: StoragePath
+    pub let publicPath: PublicPath
     pub let privatePath: PrivatePath
     pub let publicLinkedType: Type
     pub let privateLinkedType: Type
-    pub let collectionName : String
+    pub let collectionName: String
     pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let collectionExternalURL : String
+    pub let collectionSquareImage: String
+    pub let collectionBannerImage: String
+    pub let collectionExternalURL: String
     pub let royalties: [MetadataViews.Royalty]
 
     init(
-            id: UInt64,
-            name : String,
-            description : String,
-            thumbnail : String,
-            externalURL : String,
-            storagePath : StoragePath,
-            publicPath : PublicPath,
-            privatePath : PrivatePath,
-            publicLinkedType : Type,
-            privateLinkedType : Type,
-            collectionName : String,
-            collectionDescription : String,
-            collectionSquareImage : String,
-            collectionBannerImage : String,
-            collectionExternalURL : String,
-            royalties : [MetadataViews.Royalty]
+        id: UInt64,
+        name: String,
+        description: String,
+        thumbnail: String,
+        externalURL: String,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType: Type,
+        privateLinkedType: Type,
+        collectionName: String,
+        collectionDescription: String,
+        collectionSquareImage: String,
+        collectionBannerImage: String,
+        collectionExternalURL: String,
+        royalties: [MetadataViews.Royalty]
     ) {
         self.id = id
         self.name = name
@@ -57,16 +57,18 @@ pub struct NFT {
     }
 }
 
-pub fun main(ownerAddress: Address, collections: {String : [UInt64]}) : {String : [NFT] } {
-    let data : {String : [NFT] } = {}
-
+pub fun main(ownerAddress: Address, collections: {String: [UInt64]}): {String: [NFT]} {
+    let data: {String: [NFT]} = {}
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
+
     for collectionIdentifier in collections.keys {
         if catalog.containsKey(collectionIdentifier) {
             let value = catalog[collectionIdentifier]!
-            let tempPathStr = "catalog".concat(collectionIdentifier)
+            let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
+            let tempPathStr = "catalog".concat(identifierHash)
             let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
             account.link<&{MetadataViews.ResolverCollection}>(
                 tempPublicPath,
                 target: value.collectionData.storagePath
@@ -78,47 +80,47 @@ pub fun main(ownerAddress: Address, collections: {String : [UInt64]}) : {String 
                 return data
             }
 
-            let views = NFTRetrieval.getNFTViewsFromIDs(collectionIdentifier : collectionIdentifier, ids: collections[collectionIdentifier]!, collectionCap : collectionCap)
+            let views = NFTRetrieval.getNFTViewsFromIDs(collectionIdentifier: collectionIdentifier, ids: collections[collectionIdentifier]!, collectionCap: collectionCap)
 
-            let items : [NFT] = []
+            let items: [NFT] = []
 
             for view in views {
-                    let displayView = view.display
-                    let externalURLView = view.externalURL
-                    let collectionDataView = view.collectionData
-                    let collectionDisplayView = view.collectionDisplay
-                    let royaltyView = view.royalties
-                    if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
-                        // Bad NFT. Skipping....
-                        continue
-                    }
+                let displayView = view.display
+                let externalURLView = view.externalURL
+                let collectionDataView = view.collectionData
+                let collectionDisplayView = view.collectionDisplay
+                let royaltyView = view.royalties
 
-                    items.append(
-                        NFT(
-                            id: view.id,
-                            name : displayView!.name,
-                            description : displayView!.description,
-                            thumbnail : displayView!.thumbnail.uri(),
-                            externalURL : externalURLView!.url,
-                            storagePath : collectionDataView!.storagePath,
-                            publicPath : collectionDataView!.publicPath,
-                            privatePath : collectionDataView!.providerPath,
-                            publicLinkedType : collectionDataView!.publicLinkedType,
-                            privateLinkedType : collectionDataView!.providerLinkedType,
-                            collectionName : collectionDisplayView!.name,
-                            collectionDescription : collectionDisplayView!.description,
-                            collectionSquareImage : collectionDisplayView!.squareImage.file.uri(),
-                            collectionBannerImage : collectionDisplayView!.bannerImage.file.uri(),
-                            collectionExternalURL : collectionDisplayView!.externalURL.url,
-                            royalties : royaltyView!.getRoyalties()
-                        )
-                    )
+                if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
+                    // Bad NFT. Skipping....
+                    continue
                 }
 
-                data[collectionIdentifier] = items
+                items.append(
+                    NFT(
+                        id: view.id,
+                        name: displayView!.name,
+                        description: displayView!.description,
+                        thumbnail: displayView!.thumbnail.uri(),
+                        externalURL: externalURLView!.url,
+                        storagePath: collectionDataView!.storagePath,
+                        publicPath: collectionDataView!.publicPath,
+                        privatePath: collectionDataView!.providerPath,
+                        publicLinkedType: collectionDataView!.publicLinkedType,
+                        privateLinkedType: collectionDataView!.providerLinkedType,
+                        collectionName: collectionDisplayView!.name,
+                        collectionDescription: collectionDisplayView!.description,
+                        collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+                        collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+                        collectionExternalURL: collectionDisplayView!.externalURL.url,
+                        royalties: royaltyView!.getRoyalties()
+                    )
+                )
+            }
+
+            data[collectionIdentifier] = items
         }
     }
-
 
     return data
 }


### PR DESCRIPTION
The generation of `tempPublicPath` was breaking due to some Collection identifiers containing characters like `'.'` .
All seven example scripts can now be run successfully, without errors.