### PR TITLE
add `nftType` field to EntryRemoved event

### DIFF
--- a/cadence/contracts/NFTCatalog.cdc
+++ b/cadence/contracts/NFTCatalog.cdc
@@ -47,7 +47,7 @@ pub contract NFTCatalog {
 
     // EntryRemoved
     // An NFT Collection has been removed from the catalog
-    pub event EntryRemoved(collectionIdentifier : String)
+    pub event EntryRemoved(collectionIdentifier : String, nftType: Type)
 
     // ProposalEntryAdded
     // A new proposal to make an addtion to the catalog has been made
@@ -289,10 +289,10 @@ pub contract NFTCatalog {
             self.catalog[collectionIdentifier] != nil : "Invalid collection identifier"
         }
 
-        self.removeCatalogTypeEntry(collectionIdentifier : collectionIdentifier , metadata: self.catalog[collectionIdentifier]!)
+        let removedType = self.removeCatalogTypeEntry(collectionIdentifier : collectionIdentifier , metadata: self.catalog[collectionIdentifier]!)
         self.catalog.remove(key: collectionIdentifier)
 
-        emit EntryRemoved(collectionIdentifier : collectionIdentifier)
+        emit EntryRemoved(collectionIdentifier : collectionIdentifier, nftType: removedType)
     }
 
     access(account) fun updateCatalogProposal(proposalID: UInt64, proposalMetadata : NFTCatalogProposal) {
@@ -320,7 +320,7 @@ pub contract NFTCatalog {
         }
     }
 
-    access(contract) fun removeCatalogTypeEntry(collectionIdentifier : String , metadata: NFTCatalogMetadata) {
+    access(contract) fun removeCatalogTypeEntry(collectionIdentifier : String , metadata: NFTCatalogMetadata): Type {
         let prevMetadata = self.catalog[collectionIdentifier]!
         let prevCollectionsForType = self.catalogTypeData[prevMetadata.nftType.identifier]!
         prevCollectionsForType.remove(key : collectionIdentifier)
@@ -329,6 +329,8 @@ pub contract NFTCatalog {
         } else {
             self.catalogTypeData[prevMetadata.nftType.identifier] = prevCollectionsForType
         }
+
+        return metadata.nftType
     }
 
     init() {
@@ -343,3 +345,4 @@ pub contract NFTCatalog {
     }
 
 }
+ 


### PR DESCRIPTION
Adds a field to the `EntryRemoved` event so that indexers can easily pick up what contract was impacted by the removal. Without this, indexers have to keep a mapping of collectionIdentifier -> type on their own so that when a removal event comes through, they know what type it belongs to