### PR TITLE
Remove getCatalog because it is horrible for performance

### DIFF
--- a/cadence/contracts/FlowToken.cdc
+++ b/cadence/contracts/FlowToken.cdc
@@ -198,3 +198,4 @@ pub contract FlowToken: FungibleToken {
         emit TokensInitialized(initialSupply: self.totalSupply)
     }
 }
+ 

--- a/cadence/contracts/NFTCatalog.cdc
+++ b/cadence/contracts/NFTCatalog.cdc
@@ -160,12 +160,20 @@ pub contract NFTCatalog {
         }
     }
 
-    pub fun getCatalog() : {String : NFTCatalogMetadata} {
-        return self.catalog
+    pub fun forEachCatalogKey(_ function: ((String): Bool)) {
+        self.catalog.forEachKey(function)
     }
+
 
     pub fun getCatalogEntry(collectionIdentifier : String) : NFTCatalogMetadata? {
         return self.catalog[collectionIdentifier]
+    }
+
+    pub fun mustGetCatalogEntry(collectionIdentifier : String) : NFTCatalogMetadata {
+        pre{
+            self.catalog[collectionIdentifier] != nil : "Invalid collection identifier"
+        }
+        return self.catalog[collectionIdentifier]!
     }
 
     pub fun getCollectionsForType(nftTypeIdentifier: String) : {String : Bool}? {

--- a/cadence/contracts/NFTRetrieval.cdc
+++ b/cadence/contracts/NFTRetrieval.cdc
@@ -25,11 +25,7 @@ pub contract NFTRetrieval {
     }
 
     pub fun getNFTIDsFromCap(collectionIdentifier: String, collectionCap : Capability<&AnyResource{MetadataViews.ResolverCollection}>) : [UInt64] {
-        pre {
-            NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
-        }
-        let catalog = NFTCatalog.getCatalog()
-        let value = catalog[collectionIdentifier]!
+        let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: collectionIdentifier)
 
         // Check if we have multiple collections for the NFT type...
         let hasMultipleCollections = self.hasMultipleCollections(nftTypeIdentifier : value.nftType.identifier)
@@ -55,11 +51,8 @@ pub contract NFTRetrieval {
     }
 
     pub fun getNFTCountFromCap(collectionIdentifier: String, collectionCap : Capability<&AnyResource{MetadataViews.ResolverCollection}>) : UInt64 {
-        pre {
-            NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
-        }
-        let catalog = NFTCatalog.getCatalog()
-        let value = catalog[collectionIdentifier]!
+        let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: collectionIdentifier)
+
         // Check if we have multiple collections for the NFT type...
         let hasMultipleCollections = self.hasMultipleCollections(nftTypeIdentifier : value.nftType.identifier)
 
@@ -82,12 +75,8 @@ pub contract NFTRetrieval {
     }
 
     pub fun getAllMetadataViewsFromCap(collectionIdentifier: String, collectionCap : Capability<&AnyResource{MetadataViews.ResolverCollection}>) : {String: AnyStruct} {
-        pre {
-            NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
-        }
-        let catalog = NFTCatalog.getCatalog()
+        let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: collectionIdentifier)
         let items : {String: AnyStruct} = {}
-        let value = catalog[collectionIdentifier]!
 
         // Check if we have multiple collections for the NFT type...
         let hasMultipleCollections = self.hasMultipleCollections(nftTypeIdentifier : value.nftType.identifier)
@@ -112,12 +101,8 @@ pub contract NFTRetrieval {
     }
 
     pub fun getNFTViewsFromCap(collectionIdentifier: String, collectionCap : Capability<&AnyResource{MetadataViews.ResolverCollection}>) : [MetadataViews.NFTView] {
-        pre {
-            NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
-        }
-        let catalog = NFTCatalog.getCatalog()
+        let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: collectionIdentifier)
         let items : [MetadataViews.NFTView] = []
-        let value = catalog[collectionIdentifier]!
 
         // Check if we have multiple collections for the NFT type...
         let hasMultipleCollections = self.hasMultipleCollections(nftTypeIdentifier : value.nftType.identifier)
@@ -140,13 +125,8 @@ pub contract NFTRetrieval {
     }
 
     pub fun getNFTViewsFromIDs(collectionIdentifier : String, ids: [UInt64], collectionCap : Capability<&AnyResource{MetadataViews.ResolverCollection}>) : [MetadataViews.NFTView] {
-        pre {
-            NFTCatalog.getCatalog()[collectionIdentifier] != nil : "Invalid collection identifier"
-        }
-
-        let catalog = NFTCatalog.getCatalog()
+        let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: collectionIdentifier)
         let items : [MetadataViews.NFTView] = []
-        let value = catalog[collectionIdentifier]!
 
         // Check if we have multiple collections for the NFT type...
         let hasMultipleCollections = self.hasMultipleCollections(nftTypeIdentifier : value.nftType.identifier)

--- a/cadence/contracts/TransactionGenerationUtils.cdc
+++ b/cadence/contracts/TransactionGenerationUtils.cdc
@@ -170,11 +170,11 @@ pub contract TransactionGenerationUtils {
     }
 
     pub fun getNftSchema(collectionIdentifier: String): NFTSchema? {
-        let catalog = NFTCatalog.getCatalog()
-        if catalog[collectionIdentifier] == nil {
+        let catalogEntry = NFTCatalog.getCatalogEntry(collectionIdentifier: collectionIdentifier)
+        if catalogEntry== nil {
             return nil
         }
-        let catalogData = catalog[collectionIdentifier]!
+        let catalogData = catalogEntry!
 
         let publicLinkedType: Type = catalogData.collectionData.publicLinkedType
         let privateLinkedType: Type = catalogData.collectionData.privateLinkedType

--- a/cadence/scripts/get_nft_catalog.cdc
+++ b/cadence/scripts/get_nft_catalog.cdc
@@ -1,17 +1,17 @@
 import NFTCatalog from "../contracts/NFTCatalog.cdc"
 
 pub fun main(batch : [UInt64]?): {String : NFTCatalog.NFTCatalogMetadata} {
-    if batch == nil {
-        return NFTCatalog.getCatalog()
-    }
-    let catalog = NFTCatalog.getCatalog()
-    let catalogIDs = catalog.keys
     var data : {String : NFTCatalog.NFTCatalogMetadata} = {}
-    var i = batch![0]
-    while i < batch![1] {
-        data.insert(key: catalogIDs[i], catalog[catalogIDs[i]]!)
-        i = i + 1
-    }
+    // if batch == nil {
+    //     return NFTCatalog.getCatalog()
+    // }
+    // let catalog = NFTCatalog.getCatalog()
+    // let catalogIDs = catalog.keys  // <- key order is not guaranteed how does this work?
+    // var i = batch![0]
+    // while i < batch![1] {
+    //     data.insert(key: catalogIDs[i], catalog[catalogIDs[i]]!)
+    //     i = i + 1
+    // }
     return data
 }
  

--- a/cadence/scripts/get_nft_catalog_count.cdc
+++ b/cadence/scripts/get_nft_catalog_count.cdc
@@ -1,7 +1,10 @@
 import NFTCatalog from "../contracts/NFTCatalog.cdc"
 
 pub fun main(): Int {
-    let catalog = NFTCatalog.getCatalog()
-    let catalogIDs = catalog.keys
-    return catalogIDs.length
+    var count: Int = 0
+    let catalog = NFTCatalog.forEachCatalogKey(fun (key: String): Bool {
+        count = count + 1
+        return true
+    })
+    return count
 }

--- a/cadence/scripts/get_nft_in_account.cdc
+++ b/cadence/scripts/get_nft_in_account.cdc
@@ -58,13 +58,9 @@ pub struct NFT {
 }
 
 pub fun main(ownerAddress: Address, collectionIdentifier: String, tokenID: UInt64): NFT? {
-    let catalog = NFTCatalog.getCatalog()
-
-    assert(catalog.containsKey(collectionIdentifier), message: "Invalid Collection")
-
     let account = getAuthAccount(ownerAddress)
 
-    let value = catalog[collectionIdentifier]!
+    let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: collectionIdentifier)!
     let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
     let tempPathStr = "catalog".concat(identifierHash)
     let tempPublicPath = PublicPath(identifier: tempPathStr)!
@@ -79,39 +75,39 @@ pub fun main(ownerAddress: Address, collectionIdentifier: String, tokenID: UInt6
 
     let views = NFTRetrieval.getNFTViewsFromIDs(collectionIdentifier : collectionIdentifier, ids: [tokenID], collectionCap : collectionCap)
 
-    for view in views {
-        if view.id == tokenID {
-            let displayView = view.display
-            let externalURLView = view.externalURL
-            let collectionDataView = view.collectionData
-            let collectionDisplayView = view.collectionDisplay
-            let royaltyView = view.royalties
-
-            if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
-                // Bad NFT. Skipping....
-                return nil
-            }
-
-            return NFT(
-                id: view.id,
-                name: displayView!.name,
-                description: displayView!.description,
-                thumbnail: displayView!.thumbnail.uri(),
-                externalURL: externalURLView!.url,
-                storagePath: collectionDataView!.storagePath,
-                publicPath: collectionDataView!.publicPath,
-                privatePath: collectionDataView!.providerPath,
-                publicLinkedType: collectionDataView!.publicLinkedType,
-                privateLinkedType: collectionDataView!.providerLinkedType,
-                collectionName: collectionDisplayView!.name,
-                collectionDescription: collectionDisplayView!.description,
-                collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
-                collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
-                collectionExternalURL: collectionDisplayView!.externalURL.url,
-                royalties: royaltyView!.getRoyalties()
-            )
-        }
+    if views.length == 0 {
+        panic("Invalid Token ID")
     }
 
-    panic("Invalid Token ID")
+    let  view = views[0]
+
+    let displayView = view.display
+    let externalURLView = view.externalURL
+    let collectionDataView = view.collectionData
+    let collectionDisplayView = view.collectionDisplay
+    let royaltyView = view.royalties
+
+    if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
+        // Bad NFT. Skipping....
+        return nil
+    }
+
+    return NFT(
+        id: view.id,
+        name: displayView!.name,
+        description: displayView!.description,
+        thumbnail: displayView!.thumbnail.uri(),
+        externalURL: externalURLView!.url,
+        storagePath: collectionDataView!.storagePath,
+        publicPath: collectionDataView!.publicPath,
+        privatePath: collectionDataView!.providerPath,
+        publicLinkedType: collectionDataView!.publicLinkedType,
+        privateLinkedType: collectionDataView!.providerLinkedType,
+        collectionName: collectionDisplayView!.name,
+        collectionDescription: collectionDisplayView!.description,
+        collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+        collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+        collectionExternalURL: collectionDisplayView!.externalURL.url,
+        royalties: royaltyView!.getRoyalties()
+    )
 }

--- a/cadence/scripts/get_nfts_in_account_from_ids.cdc
+++ b/cadence/scripts/get_nfts_in_account_from_ids.cdc
@@ -59,67 +59,69 @@ pub struct NFT {
 
 pub fun main(ownerAddress: Address, collections: {String: [UInt64]}): {String: [NFT]} {
     let data: {String: [NFT]} = {}
-    let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
 
     for collectionIdentifier in collections.keys {
-        if catalog.containsKey(collectionIdentifier) {
-            let value = catalog[collectionIdentifier]!
-            let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
-            let tempPathStr = "catalog".concat(identifierHash)
-            let tempPublicPath = PublicPath(identifier: tempPathStr)!
-
-            account.link<&{MetadataViews.ResolverCollection}>(
-                tempPublicPath,
-                target: value.collectionData.storagePath
-            )
-
-            let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
-
-            if !collectionCap.check() {
-                return data
-            }
-
-            let views = NFTRetrieval.getNFTViewsFromIDs(collectionIdentifier: collectionIdentifier, ids: collections[collectionIdentifier]!, collectionCap: collectionCap)
-
-            let items: [NFT] = []
-
-            for view in views {
-                let displayView = view.display
-                let externalURLView = view.externalURL
-                let collectionDataView = view.collectionData
-                let collectionDisplayView = view.collectionDisplay
-                let royaltyView = view.royalties
-
-                if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
-                    // Bad NFT. Skipping....
-                    continue
-                }
-
-                items.append(
-                    NFT(
-                        id: view.id,
-                        name: displayView!.name,
-                        description: displayView!.description,
-                        thumbnail: displayView!.thumbnail.uri(),
-                        externalURL: externalURLView!.url,
-                        storagePath: collectionDataView!.storagePath,
-                        publicPath: collectionDataView!.publicPath,
-                        privatePath: collectionDataView!.providerPath,
-                        publicLinkedType: collectionDataView!.publicLinkedType,
-                        privateLinkedType: collectionDataView!.providerLinkedType,
-                        collectionName: collectionDisplayView!.name,
-                        collectionDescription: collectionDisplayView!.description,
-                        collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
-                        collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
-                        collectionExternalURL: collectionDisplayView!.externalURL.url,
-                        royalties: royaltyView!.getRoyalties()
-                    )
-                )
-            }
-
-            data[collectionIdentifier] = items
+        let catalogEntry = NFTCatalog.getCatalogEntry(collectionIdentifier: collectionIdentifier)
+        if catalogEntry == nil {
+            continue
         }
+
+        let value = catalogEntry!
+        let identifierHash = String.encodeHex(HashAlgorithm.SHA3_256.hash(collectionIdentifier.utf8))
+        let tempPathStr = "catalog".concat(identifierHash)
+        let tempPublicPath = PublicPath(identifier: tempPathStr)!
+
+        account.link<&{MetadataViews.ResolverCollection}>(
+            tempPublicPath,
+            target: value.collectionData.storagePath
+        )
+
+        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+
+        if !collectionCap.check() {
+            return data
+        }
+
+        let views = NFTRetrieval.getNFTViewsFromIDs(collectionIdentifier: collectionIdentifier, ids: collections[collectionIdentifier]!, collectionCap: collectionCap)
+
+        let items: [NFT] = []
+
+        for view in views {
+            let displayView = view.display
+            let externalURLView = view.externalURL
+            let collectionDataView = view.collectionData
+            let collectionDisplayView = view.collectionDisplay
+            let royaltyView = view.royalties
+
+            if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
+                // Bad NFT. Skipping....
+                continue
+            }
+
+            items.append(
+                NFT(
+                    id: view.id,
+                    name: displayView!.name,
+                    description: displayView!.description,
+                    thumbnail: displayView!.thumbnail.uri(),
+                    externalURL: externalURLView!.url,
+                    storagePath: collectionDataView!.storagePath,
+                    publicPath: collectionDataView!.publicPath,
+                    privatePath: collectionDataView!.providerPath,
+                    publicLinkedType: collectionDataView!.publicLinkedType,
+                    privateLinkedType: collectionDataView!.providerLinkedType,
+                    collectionName: collectionDisplayView!.name,
+                    collectionDescription: collectionDisplayView!.description,
+                    collectionSquareImage: collectionDisplayView!.squareImage.file.uri(),
+                    collectionBannerImage: collectionDisplayView!.bannerImage.file.uri(),
+                    collectionExternalURL: collectionDisplayView!.externalURL.url,
+                    royalties: royaltyView!.getRoyalties()
+                )
+            )
+        }
+
+        data[collectionIdentifier] = items
     }
 
     return data

--- a/flow.json
+++ b/flow.json
@@ -84,55 +84,6 @@
         "emulator-account": {
             "address": "0xf8d6e0586b0a20c7",
             "key": "ff735bbeae75401fbd8cd05c0b5f154038642bc226103eddc987c7e35bacb96d"
-        },
-        "catalog-testnet-account": {
-            "address": "0x324c34e1c517e4db",
-            "key": "$CATALOG_TESTNET_ACCOUNT_PRIVATE_KEY"
-        },
-        "transaction-generation-testnet-account": {
-            "address": "0x44051d81c4720882",
-            "key": "$CATALOG_TESTNET_ACCOUNT_PRIVATE_KEY"
-        },
-        "examplenft-testnet-account": {
-            "address": "0xa60cf32e8369f919",
-            "key": "ff735bbeae75401fbd8cd05c0b5f154038642bc226103eddc987c7e35bacb96d"
-        },
-        "examplenft-testnet-holder-account": {
-            "address": "0x5f151d59c7128d8e",
-            "key": "ff735bbeae75401fbd8cd05c0b5f154038642bc226103eddc987c7e35bacb96d"
-        },
-        "mainnet-nft-catalog-account": {
-            "address": "0x49a7cda3a1eecc29",
-            "key": {
-                "type": "google-kms",
-                "index": 0,
-                "signatureAlgorithm": "ECDSA_P256",
-                "hashAlgorithm": "SHA2_256",
-                "resourceID": "projects/dl-flow-admin/locations/global/keyRings/nft-metadata/cryptoKeys/nft-catalog/cryptoKeyVersions/1"
-            },
-            "chain": "flow-mainnet"
-        },
-        "mainnet-transaction-generation-account": {
-            "address": "0xe52522745adf5c34",
-            "key": {
-                "type": "google-kms",
-                "index": 0,
-                "signatureAlgorithm": "ECDSA_P256",
-                "hashAlgorithm": "SHA2_256",
-                "resourceID": "projects/dl-flow-admin/locations/global/keyRings/nft-metadata/cryptoKeys/nft-catalog-admin/cryptoKeyVersions/1"
-            },
-            "chain": "flow-mainnet"
-        },
-        "mainnet-nft-catalog-admin-account": {
-            "address": "0xf589fc579a72e43d",
-            "key": {
-                "type": "google-kms",
-                "index": 0,
-                "signatureAlgorithm": "ECDSA_P256",
-                "hashAlgorithm": "SHA2_256",
-                "resourceID": "projects/dl-flow-admin/locations/global/keyRings/nft-metadata/cryptoKeys/nft-catalog-admin/cryptoKeyVersions/1"
-            },
-            "chain": "flow-mainnet"
         }
     },
     "deployments": {
@@ -151,34 +102,6 @@
                 "FlowUtilityToken",
                 "NFTStorefrontV2",
                 "TokenForwarding",
-                "TransactionGenerationUtils",
-                "TransactionTemplates",
-                "TransactionGeneration"
-            ]
-        },
-        "testnet": {
-            "catalog-testnet-account": [
-                "NFTCatalog",
-                "NFTCatalogAdmin",
-                "NFTRetrieval"
-            ],
-            "transaction-generation-testnet-account": [
-                "ArrayUtils",
-                "StringUtils",
-                "TransactionGenerationUtils",
-                "TransactionTemplates",
-                "TransactionGeneration"
-            ]
-        },
-        "mainnet": {
-            "mainnet-nft-catalog-account": [
-                "NFTCatalog",
-                "NFTCatalogAdmin",
-                "NFTRetrieval"
-            ],
-            "mainnet-transaction-generation-account": [
-                "ArrayUtils",
-                "StringUtils",
                 "TransactionGenerationUtils",
                 "TransactionTemplates",
                 "TransactionGeneration"

--- a/ui/test.cdc
+++ b/ui/test.cdc
@@ -54,13 +54,12 @@ pub struct NFT {
 }
 
 pub fun main(ownerAddress: Address) : { String : [NFT] } {
-    let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
 
     let data : {String : [NFT] } = {}
 
-    for key in catalog.keys {
-        let value = catalog[key]!
+    NFTCatalog.forEachCatalogKey(fun (key: String): Bool {
+        let value = NFTCatalog.mustGetCatalogEntry(collectionIdentifier: key)
         let tempPathStr = "catalog".concat(key)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
         account.link<&{MetadataViews.ResolverCollection}>(
@@ -80,7 +79,7 @@ pub fun main(ownerAddress: Address) : { String : [NFT] } {
             let royaltyView = view.royalties
             if (displayView == nil || externalURLView == nil || collectionDataView == nil || collectionDisplayView == nil || royaltyView == nil) {
                 // Bad NFT. Skipping....
-                continue
+                return true
             }
 
             items.append(
@@ -104,6 +103,7 @@ pub fun main(ownerAddress: Address) : { String : [NFT] } {
             )
         }
         data[key] = items
-    }
+        return true
+    })
     return data
 }


### PR DESCRIPTION
every-time `getCatalog` is called this fetches the entire catalog from storage and copies it. This is terrible, especially since the catalog is growing.

If a specific element is needed just use the existing `getCatalogEntry` or the newly added `mustGetCatalogEntry` which just has the pre-check that was duplicated everywhere in one place.

Iteration over the entire catalog should only be used if really needed. In that case I added `forEachCatalogKey` method.

Be aware that there are examples and scripts that recommend just iterating one `catalog.keys.slice` (or equivalent). This is not a good recommendation! `catalog.keys` are not deterministically sorted! using this for paging will lead to bugs. A different mechanism should be put in place for paging.

Another performance change that I added to this is the switch from `getNFTViewsFromCap` to `getNFTViewsFromIDs` in cadence/scripts/get_nft_and_views_in_account.cdc. Because only views for a specific ID are needed, so no need getting all of them.

missing from the draft:
- I have not tested everything
- I don't know what to do with the examples that use paging
- I haven't checked any javascript code (I don't know if anything is needed)